### PR TITLE
switch to https urls in the DS_NPR_API class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Travis CI Configuration File
 
 # Use Travis CI container-based infrastructure
-# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+# See: https://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
 # Tell Travis CI we're using PHP
@@ -32,7 +32,7 @@ branches:
 # Clones WordPress and configures our testing environment.
 before_script:
     - export SLUG=$(basename $(pwd))
-    - svn co --quiet http://develop.svn.wordpress.org/tags/$WP_VERSION $WP_CORE_DIR
+    - svn co --quiet https://develop.svn.wordpress.org/tags/$WP_VERSION $WP_CORE_DIR
     - cd ..
     - mv $SLUG "$WP_CORE_DIR/src/wp-content/plugins/$SLUG"
     - cd $WP_CORE_DIR

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc., <https://fsf.org/>
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Push requires an Organization ID in the NPR API, which is typically given out to
 
 = Where can I find NPR's documentation on the NPR API? =
 
-There is some documentation in the NPR API site: [http://www.npr.org/api/index.php](http://www.npr.org/api/index.php).
+There is some documentation in the NPR API site: [https://www.npr.org/api/index.php](https://www.npr.org/api/index.php).
 
 = Is there an easy way to directly query the NPR API? =
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Stable tag: 1.6
 
 License: GPLv2
 
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
@@ -20,9 +20,9 @@ The NPR Story API Plugin provides push and pull functionality with the NPR API a
 
 NPR's API is a content API, which essentially provides a structured way for other computer applications to get NPR stories in a predictable, flexible and powerful way. The content that is available includes audio from most NPR programs dating back to 1995 as well as text, images and other web-only content from NPR and NPR member stations. This archive consists of over 250,000 stories that are grouped into more than 5,000 different aggregations.
 
-Access to the NPR API requires an API Key which you can get by [registering for an NPR account](http://www.npr.org/account/signup).
+Access to the NPR API requires an API Key which you can get by [registering for an NPR account](https://secure.npr.org/oauth2/login).
 
-The WordPress plugin is being developed as an Open Source plugin by NPR Digital Services. If you would like to suggest features or bug fixes, or better yet if you would like to contribute new features or bug fixes please contact Digital Services through our support page at [http://info.ds.npr.org/support.html](http://info.ds.npr.org/support.html).
+The WordPress plugin is being developed as an Open Source plugin by NPR Digital Services. If you would like to suggest features or bug fixes, or better yet if you would like to contribute new features or bug fixes please contact Digital Services through our support page at [https://nprsupport.desk.com/](https://nprsupport.desk.com/).
 
 == Installation ==
 
@@ -35,7 +35,7 @@ The WordPress plugin is being developed as an Open Source plugin by NPR Digital 
 
 = Can anyone get an NPR API Key? =
 
-That's up to NPR but you can [register for an account here](http://www.npr.org/account/signup).
+That's up to NPR but you can [register for an account here](https://secure.npr.org/oauth2/login).
 
 = Can anyone push content into the NPR API using this plugin? =
 
@@ -45,11 +45,11 @@ Push requires an Organization ID in the NPR API, which is typically given out to
 
 The best resource for general information about the NPR API is here: [https://nprsupport.desk.com/customer/en/portal/topics/783619-api/articles](https://nprsupport.desk.com/customer/en/portal/topics/783619-api/articles).
 
-There's also the documentation in the NPR API site: [http://www.npr.org/api/index.php](http://www.npr.org/api/index.php).
+There's also the documentation in the NPR API site: [https://www.npr.org/api/index.php](https://www.npr.org/api/index.php).
 
 = Is there an easy way to directly query the NPR API? =
 
-You bet, just visit the NPR Query Generator: [http://www.npr.org/api/queryGenerator.php](http://www.npr.org/api/queryGenerator.php)
+You bet, just visit the NPR Query Generator: [https://www.npr.org/api/queryGenerator.php](https://www.npr.org/api/queryGenerator.php)
 
 == Screenshots ==
 
@@ -106,7 +106,7 @@ NPR Stories having got gotten
 * Multiple Bylines for pulled stories -  When an API story has multiple bylines, we will now populate a meta field `npr_multi_byline` with a pipe (|) deliminated list of names.  If the author also has a link for thier byline then there'll be a tilde (~) separating the author's name and the link.
   - An example of data for multiple bylines:
 
-		Ari Shapiro~http://www-s2.npr.org/people/2101154/ari-shapiro|kmoylan@npr.org|Tommy Writer
+		Ari Shapiro~https://www.npr.org/people/2101154/ari-shapiro|kmoylan@npr.org|Tommy Writer
 
   - Here there are three authors for this story, Ari Shapiro (and his bio link), then "kmoylan@npr.org" and a third author "Tommy Writer". Single author stories will not be changed. (This fix came from Ryan Tainter at KERA. Thanks, Ryan!)
 
@@ -116,7 +116,7 @@ NPR Stories having got gotten
 
 * Reversed the order of images and audio that are being pushed to the NPR API.  We're now sending them in the order the file was created.
 * Mapping of media credit and agency - If you have a field that you are storing image credit and agency, you can now send these to the NPR API. In making this change we needed to expose meta fields that begin with an underscore.  So you may see more meta fields visable on the mapping page.
-* Multiple bylines are now being pushed to the NPR API if you use the plugin co-author-plus (<http://wordpress.org/plugins/co-authors-plus/>) We insert a byline row for each of the co-authors of a post when we push. You can still use a custom byline field if you want to use that along with the co-authors plugin.
+* Multiple bylines are now being pushed to the NPR API if you use the plugin co-author-plus (<https://wordpress.org/plugins/co-authors-plus/>) We insert a byline row for each of the co-authors of a post when we push. You can still use a custom byline field if you want to use that along with the co-authors plugin.
 * Retrieved story dates -  Now when you retrieve a story from the NPR API the published date for WordPress will be the date from the <storyDate> field in the NPR API. This will better allow stories to fall into their natural order when publishing from the Get Multi page. It's always possible to edit the date by hand when pulling single stories from the NPR API. Do remember though that you are contractually obligated to show the original date when rendering a story from the NPR API.
 * Retrieved story order -  When you retrieve stories from the API, if you do not include a `sort` parameter in your query, we will insure that the order of the stories is in reverse cron for any stories that have the same storyDate in the API. Often some aggregate groups in the API will publish stories with the same storyDate. Shows like Morning Edition do this often, and prior to this fix stories would appear to be published in reverse order from what the API shows.  Now if you do not include `sort` in your query, the stories with the same time will be published in the same order as the API shows them.
 * Configurable Cron interval -  When you use the Get Multi page, which fires off of wp-cron, you can now set the interval for the wp-cron to fire. This is on the Get Multi configuration page, and allows you to enter a number of minutes you want as your wp-cron interval. If you enter any thing that is not a number, or a number less than 1, we will resolve that to 60 minutes...because, well, that's a resonable interval, and the wp-cron doesn't understand 'every now and then' as an interval.
@@ -139,7 +139,7 @@ NPR Stories having got gotten
 
 = V1.3 =
 
-* Permissions - If you have created any NPR API Permissions Groups you can select which (if any) group you would like to use as your default group when pushing content to the NPR API.  Learn more about NPR API Permissions Groups here: <http://digitalservices.npr.org/post/npr-api-content-permissions-control>
+* Permissions - If you have created any NPR API Permissions Groups you can select which (if any) group you would like to use as your default group when pushing content to the NPR API.  Learn more about NPR API Permissions Groups here: <https://digitalservices.npr.org/post/npr-api-content-permissions-control>
 * Multi-Site - Cron set up and other activation tasks will now happen on every site in a multi-site configuration.
 * Cron queries - We won't try to query for any of the configured queries on the Get Multi page if the field isn't filled in with data.
 * Content and short codes - Instead of blindly removing all shortcodes from a story's content, we are now trying to let any plugins replace the shortcodes with HTML, and then if there are any leftover shortcodes (we delete those?).
@@ -156,10 +156,10 @@ This version will allow admins to configure their WordPress site to retrieve mul
 
 * From the Admin -> Settings -> NPR API Get Multi page (wp-admin/options-general.php?page=ds_npr_api_get_multi_settings) an admin can add a number of queries.
 * These query entries can contain an API ID for a single story, or an ID for a specific category, program, topic, etc.
-* The query can also contain the full query string can be created from the NPR API Query Generator: <http://www.npr.org/api/queryGenerator.php>
+* The query can also contain the full query string can be created from the NPR API Query Generator: <https://www.npr.org/api/queryGenerator.php>
 * You can also enter the URL for a story you found on npr.org.
 * The entered queries will be executed via the Wordpress cron functionality, hourly.
-* Any new stories that are available will be automatically published.  You can find a list of query filters at the npr.org's API documentation page: <http://www.npr.org/api/inputReference.php>
+* Any new stories that are available will be automatically published.  You can find a list of query filters at the npr.org's API documentation page: <https://www.npr.org/api/inputReference.php>
 * Stories retrieved from the NPR API will be created as Posts in WordPress.  Each post will have a number of meta fields associated with the post.  These meta fields will all begin with `npr_` and can be viewed on a post edit screen with Custom Fields option enabled through Screen Options. A story from the API that has a primary image defined will have that image set as the featured image of the Wordpress post.  Any bylines for the NPR Story will be stored in the meta field `npr_byline`. The list of npr_ meta fields is:
 
 		npr_api_link
@@ -180,11 +180,11 @@ This version will allow admins to configure their WordPress site to retrieve mul
 As not a lot of users have installed the V1.0 of the NPR API Plugin, there are a couple of things to keep in mind.
 
 * On the NPR API settings page (wp-admin/options-general.php?page=ds_npr_api) there are 4 fields.
-  - API KEY - This is your NPR API Key that you can get from NPR.  If you wish to push stories to the NPR API you'll need to have your key configured by NPR Digital Services.  Please contact Digital Services with a support request at <http://info.ds.npr.org//support.html>
-  - Pull URL - This is the root url for retrieving stories.  For testing purposes, you should configure this to be `http://api-s1.npr.org`. NOTE: this url should not contain a trailing slash.
-  - Push URL - Much like the pull url, this url is used to pushing stories to the NPR API. Again, for testing purposes, you can utilize NPR's staging server  at `http://api-s1.npr.org`. If you do not wish to push your content, or your NPR API has not been authorized, you should leave this field empty and the WordPress plugin will not attempt to push you content to the NPR API.
-  - Org ID - This is your organization's ID assigned by NPR.  If you don't know your Org ID, please contact Digital Services at: <http://info.ds.npr.org/support.html>
-* You can pull stories one at a time from the NPR API by using the Get NPR Stories page under admin Posts menu (wp-admin/edit.php?page=get-npr-stories). This can be story ID from the API, or the URL for the story from npr.org. For help in finding possible query options, please use the Query Generator at <http://www.npr.org/api/queryGenerator.php> Documentation is at: <http://www.npr.org/api/inputReference.php>
+  - API KEY - This is your NPR API Key that you can get from NPR.  If you wish to push stories to the NPR API you'll need to have your key configured by NPR Digital Services.  Please contact Digital Services with a support request at <https://info.ds.npr.org//support.html>
+  - Pull URL - This is the root url for retrieving stories.  For testing purposes, you should configure this to be `https://api-s1.npr.org`. NOTE: this url should not contain a trailing slash.
+  - Push URL - Much like the pull url, this url is used to pushing stories to the NPR API. Again, for testing purposes, you can utilize NPR's staging server  at `https://api-s1.npr.org`. If you do not wish to push your content, or your NPR API has not been authorized, you should leave this field empty and the WordPress plugin will not attempt to push you content to the NPR API.
+  - Org ID - This is your organization's ID assigned by NPR.  If you don't know your Org ID, please contact Digital Services at: <https://info.ds.npr.org/support.html>
+* You can pull stories one at a time from the NPR API by using the Get NPR Stories page under admin Posts menu (wp-admin/edit.php?page=get-npr-stories). This can be story ID from the API, or the URL for the story from npr.org. For help in finding possible query options, please use the Query Generator at <https://www.npr.org/api/queryGenerator.php> Documentation is at: <https://www.npr.org/api/inputReference.php>
 
 == Upgrade Notice ==
 

--- a/classes/NPRAPI.php
+++ b/classes/NPRAPI.php
@@ -14,7 +14,7 @@ class NPRAPI {
   const NPRAPI_STATUS_OK = 200;
 
   // Default URL for pulling stories
-  const NPRAPI_PULL_URL = 'http://api.npr.org';
+  const NPRAPI_PULL_URL = 'https://api.npr.org';
 
   // NPRML CONSTANTS
   const NPRML_DATA = '<?xml version="1.0" encoding="UTF-8"?><nprml></nprml>';

--- a/classes/NPRAPI.php
+++ b/classes/NPRAPI.php
@@ -18,7 +18,7 @@ class NPRAPI {
 
   // NPRML CONSTANTS
   const NPRML_DATA = '<?xml version="1.0" encoding="UTF-8"?><nprml></nprml>';
-  const NPRML_NAMESPACE = 'xmlns:nprml=http://api.npr.org/nprml';
+  const NPRML_NAMESPACE = 'xmlns:nprml=https://api.npr.org/nprml';
   const NPRML_VERSION = '0.92.2';
 
   /**

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -22,7 +22,7 @@ class NPRAPIWordpress extends NPRAPI {
    *
    *
    * @param string $path
-   *   The path part of the request URL (i.e., http://example.com/PATH).
+   *   The path part of the request URL (i.e., https://example.com/PATH).
    *
    * @param string $base
    *   The base URL of the request (i.e., HTTP://EXAMPLE.COM/path) with no trailing slash.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name"       : "nprds/nprapi-wordpress",
   "description": "Access the NPR API from within Wordpress",
-  "homepage"   : "http://digitalservices.npr.org/",
+  "homepage"   : "https://digitalservices.npr.org/",
   "type"       : "wordpress-plugin",
   "license"    : "GPL-2.0+"
 }

--- a/contributing.md
+++ b/contributing.md
@@ -1,3 +1,3 @@
 # Contributing
 
-The WordPress plugin is being developed as an Open Source plugin by NPR Digital Services. If you would like to suggest features or bug fixes, or better yet if you would like to contribute new features or bug fixes please contact Digital Services through our support page at [http://info.ds.npr.org/support.html](http://info.ds.npr.org/support.html).
+The WordPress plugin is being developed as an Open Source plugin by NPR Digital Services. If you would like to suggest features or bug fixes, or better yet if you would like to contribute new features or bug fixes please contact Digital Services through our support page at [https://info.ds.npr.org/support.html](https://info.ds.npr.org/support.html).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,11 +3,11 @@
 1. Download the plugin files from this repository
 2. Unzip and upload the unzipped plugin folder to the `/wp-content/plugins/` directory of your WordPress install OR go to **Plugins > Add New** from the WordPress dashboard and upload the plugin zip file
 3. Activate the plugin through the **Plugins** screen in WordPress
-4. Use the **Settings > NPR API** screen to configure the plugin. Begin by entering your API Key, then add your Push URL and Org ID. 
+4. Use the **Settings > NPR API** screen to configure the plugin. Begin by entering your API Key, then add your Push URL and Org ID.
 
-If you don't have an API Key or Org ID you can request them by [registering for an NPR account](http://www.npr.org/account/signup). 
+If you don't have an API Key or Org ID you can request them by [registering for an NPR account](https://secure.npr.org/oauth2/login).
 
-The Push URL for the NPR Production API is `https://api.npr.org`. 
+The Push URL for the NPR Production API is `https://api.npr.org`.
 
 The Push URL for testing purposes is `https://api-s1.npr.org`.
 

--- a/docs/npr-one.md
+++ b/docs/npr-one.md
@@ -1,11 +1,11 @@
 # Pushing Posts to NPR One 
 
-You can easily push posts to the [NPR One mobile app](http://www.npr.org/about/products/npr-one/) in addition to the NPR API. 
+You can easily push posts to the [NPR One mobile app](https://www.npr.org/about/products/npr-one/) in addition to the NPR API.
 
 After you [set up the WordPress NPR API Plugin](settings.md) with your API Key and Org ID, you will see a new checkbox in the Post Edit screen for "Send to NPR One":
 
 ![Send to NPR One checkbox in the WordPress post edit screen](assets/img/test-post-npr-one.png)
 
-The checkbox is not selected by default. This allows you to push all your stories to the NPR API, but only selected stories to NPR One. 
+The checkbox is not selected by default. This allows you to push all your stories to the NPR API, but only selected stories to NPR One.
 
-If you want to push a post to NPR One, check the box and hit the Publish or Update button. 
+If you want to push a post to NPR One, check the box and hit the Publish or Update button.

--- a/docs/pulling-multiple-stories.md
+++ b/docs/pulling-multiple-stories.md
@@ -8,13 +8,13 @@ In the WordPress Dashboard go to **Settings > NPR API Get Multi**. This screen o
 
 Note that "Query String" simply means a URL containing query parameters like a Subject ID, content type, date range, number of results to return, etc. An NPR API query string looks something like this:
 
-`http://api.npr.org/query?id=1014,2&requiredAssets=audio&startDate=2016-04-01&endDate=2016-06-05&dateType=story&output=NPRML&numResults=10`
+`https://api.npr.org/query?id=1014,2&requiredAssets=audio&startDate=2016-04-01&endDate=2016-06-05&dateType=story&output=NPRML&numResults=10`
 
 You can enter multiple query strings to pull content for different subjects, programs, etc., and set how often the queries will run. Once you save one or more queries, WordPress will continue to run them against the NPR API and return fresh stories as  WordPress Posts or Drafts.
 
 ## How to Create a Query String
 
-You can easily create query strings for API content by visiting the [NPR API Query Generator](http://www.npr.org/api/queryGenerator.php). The Query Generator provides a graphical user interface to create queries by topic, blogs, program, series, stations, and other values in the NPR API. Note that the **Control** tab of the Query Generator adds filtering by date or date range, search terms, and content type. You can also specify the number of results to return for a given query. 
+You can easily create query strings for API content by visiting the [NPR API Query Generator](https://www.npr.org/api/queryGenerator.php). The Query Generator provides a graphical user interface to create queries by topic, blogs, program, series, stations, and other values in the NPR API. Note that the **Control** tab of the Query Generator adds filtering by date or date range, search terms, and content type. You can also specify the number of results to return for a given query. 
 
 After creating a query in the Query Generator, click the button to **Create API Call**:
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,12 +1,12 @@
 # NPR API Plugin Docs
 
-The NPR Story API Plugin provides push and pull functionality with the [NPR API](http://www.npr.org/api/index) along with a user-friendly administrative interface.
+The NPR Story API Plugin provides push and pull functionality with the [NPR API](https://www.npr.org/api/index) along with a user-friendly administrative interface.
 
 NPR's API is a content API, which essentially provides a structured way for other computer applications to pull NPR stories in a predictable, flexible and powerful way. The content that is available includes audio from most NPR programs dating back to 1995 as well as text, images and other web-only content from NPR and NPR member stations. This archive consists of over 250,000 stories that are grouped into more than 5,000 different aggregations.
 
-Access to the NPR API requires an API Key which you can get by [registering for an NPR account](http://www.npr.org/account/signup).
+Access to the NPR API requires an API Key which you can get by [registering for an NPR account](https://secure.npr.org/oauth2/login).
 
-The WordPress plugin is being developed as an Open Source plugin by NPR Digital Services. If you would like to suggest features or bug fixes, or better yet if you would like to contribute new features or bug fixes please contact Digital Services through our support page at [http://info.ds.npr.org/support.html](http://info.ds.npr.org/support.html).
+The WordPress plugin is being developed as an Open Source plugin by NPR Digital Services. If you would like to suggest features or bug fixes, or better yet if you would like to contribute new features or bug fixes please contact Digital Services through our support page at [https://info.ds.npr.org/support.html](https://info.ds.npr.org/support.html).
 
 ## Docs Table of Contents
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -2,23 +2,23 @@
 
 ## Before you start
 
-To pull content from the NPR API you'll need an API Key which you can get by [registering for an NPR account](http://www.npr.org/account/signup). Once your account is approved by NPR you can [sign in](http://www.npr.org/account/login) and copy your NPR API key from the developer section at the bottom of the page:
+To pull content from the NPR API you'll need an API Key which you can get by [registering for an NPR account](https://secure.npr.org/oauth2/login). Once your account is approved by NPR you can [sign in](https://secure.npr.org/oauth2/login) and copy your NPR API key from the developer section at the bottom of the page:
 
 ![NPR account page showing the API key in the developer section of the page](assets/img/npr-sccount-page.png)
 
 If you are planning to push content to the NPR API you'll also need an NPR API Org ID. If you are an NPR station or affiliated producer you can find your Org ID at [NPR StationConnect](https://stationconnect.org/login?redirect=%2F). 
 
-If you don't have an Org ID or don't intend to push content into the NPR API you can still pull content from the API, but be mindful of the [Terms of Use](http://www.npr.org/about-npr/179876898/terms-of-use).
+If you don't have an Org ID or don't intend to push content into the NPR API you can still pull content from the API, but be mindful of the [Terms of Use](https://www.npr.org/about-npr/179876898/terms-of-use).
 
 ## Configure your settings
 
-With your API Key in hand, visit the **Settings > NPR API** settings screen in your WordPress dashboard. Enter your API Key, and if available your Org ID. 
+With your API Key in hand, visit the **Settings > NPR API** settings screen in your WordPress dashboard. Enter your API Key, and if available your Org ID.
 
-For the producation API, the value for both Pull URL and Push URL is `http://api.npr.org`. If you wish to use the sandbox version of the API for testing, the URL for both Push and Pull is `https://api-s1.npr.org`.
+For the producation API, the value for both Pull URL and Push URL is `https://api.npr.org`. If you wish to use the sandbox version of the API for testing, the URL for both Push and Pull is `https://api-s1.npr.org`.
 
 For NPR Pull Post Type you can leave the default or pick a custom post type. You can pull stories into the custom post type to keep them organized separately from your site's regular posts. For example if you select an NPR Pull Post Type of `npr_story_post` you will find all pulled stories in a new dashboard link labelled **NPR Stories**, just below the dashboard link for **Posts**.
 
-For NPR Push Post Type you can leave the default or set it to another post type, like `post`. 
+For NPR Push Post Type you can leave the default or set it to another post type, like `post`.
 
 If you have configured any Permissions Groups for content you distribute through the NPR API you can optionally add them in the NPR Permissions setting. Note that by default all content in the NPR API is open to everyone, unless you restrict access to a Permissions Group. For more on setting these up see the [NPR API Content Permissions Control page](https://nprsupport.desk.com/customer/en/portal/articles/1995557-npr-api-content-permissions-control).
 

--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -92,7 +92,7 @@ function nprstory_activate() {
 		update_option( 'ds_npr_num', 5 );
 	}
 	
-	$def_url = 'http://api.npr.org';
+	$def_url = 'https://api.npr.org';
 	$pull_url = get_option( 'ds_npr_api_pull_url' );
 	if ( empty( $pull_url ) ) {
 		update_option( 'ds_npr_api_pull_url', $def_url );

--- a/get_stories.php
+++ b/get_stories.php
@@ -109,10 +109,10 @@ class DS_NPR_API {
             } else {
                 // url format: /yyyy/mm/dd/id
 				// url format: /blogs/name/yyyy/mm/dd/id
-				$story_id = preg_replace( '/http\:\/\/[^\s\/]*npr\.org\/((([^\/]*\/){3,5})([0-9]{8,12}))\/.*/', '$4', $story_id );
+				$story_id = preg_replace( '/https?\:\/\/[^\s\/]*npr\.org\/((([^\/]*\/){3,5})([0-9]{8,12}))\/.*/', '$4', $story_id );
 				if ( ! is_numeric( $story_id ) ) {
 				    // url format: /templates/story/story.php?storyId=id
-				    $story_id = preg_replace( '/http\:\/\/[^\s\/]*npr\.org\/([^&\s\<]*storyId\=([0-9]+)).*/', '$2', $story_id );
+					$story_id = preg_replace( '/https?\:\/\/[^\s\/]*npr\.org\/([^&\s\<]*storyId\=([0-9]+)).*/', '$2', $story_id );
 				}
             }
 		}

--- a/get_stories.php
+++ b/get_stories.php
@@ -43,7 +43,7 @@ class DS_NPR_API {
 					 */
 					if ( stristr( $query_string, 'http:' ) || stristr( $query_string, 'https:' ) ) {
 						error_log( sprintf(
-							'Not going to run query because the query string %1$s contains http: or https: and is not pointing to the pullURL %2$s'
+							'Not going to run query because the query string %1$s contains http: or https: and is not pointing to the pullURL %2$s',
 							var_export( $query_string, true ),
 							var_export( get_option( 'ds_npr_api_pull_url' ), true )
 						) ); // debug use

--- a/get_stories.php
+++ b/get_stories.php
@@ -32,17 +32,24 @@ class DS_NPR_API {
 			$q = 'ds_npr_query_' . $i;
 			$query_string = get_option( $q );
 			if ( ! empty( $query_string ) ) {
-				nprstory_error_log('Cron '. $i . ' querying NPR API for ' . $query_string);
+				nprstory_error_log( 'Cron '. $i . ' querying NPR API for ' . $query_string );
 				//if the query string contains the pull url and 'query', just make request from the API
 				if ( stristr( $query_string, get_option( 'ds_npr_api_pull_url' ) ) && stristr( $query_string,'query' ) ) {
 					$api->query_by_url( $query_string );
 				} else {
-				    //if the string doesn't contain the base url, try to query using an ID
-					if ( stristr( $query_string, 'http:' ) ) {
-						error_log('Not going to run query because the query string contains http and is not pointing to the pullURL: ' . $query_string ); // debug use
+					/*
+					 * If the string doesn't contain the base URL, try to query using an ID
+					 * but only if the query string is not a URL in its own right.
+					 */
+					if ( stristr( $query_string, 'http:' ) || stristr( $query_string, 'https:' ) ) {
+						error_log( sprintf(
+							'Not going to run query because the query string %1$s contains http: or https: and is not pointing to the pullURL %2$s'
+							var_export( $query_string, true ),
+							var_export( get_option( 'ds_npr_api_pull_url' ), true )
+						) ); // debug use
 					} else {
 						$params = array ('id' => $query_string, 'apiKey' => get_option( 'ds_npr_api_key' ));
-                        $api->request( $params, 'query', get_option( 'ds_npr_api_pull_url' ) );
+						$api->request( $params, 'query', get_option( 'ds_npr_api_pull_url' ) );
 					}
 				}
 				$api->parse();

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 === NPR Story API ===
 Contributors: nprds, inn_nerds
-Donate link: http://www.npr.org/series/750002/support-public-radio
+Donate link: https://www.npr.org/series/750002/support-public-radio
 Tags: npr, news, public radio, api
 Requires at least: 3.8.14
 Tested up to: 4.5.2
 Stable tag: 1.6
 License: GPLv2
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 A collection of tools for reusing content from NPR.org supplied by Digital Services.
 
@@ -16,9 +16,9 @@ The NPR Story API Plugin provides push and pull functionality with the NPR API a
 
 NPR's API is a content API, which essentially provides a structured way for other computer applications to get NPR stories in a predictable, flexible and powerful way. The content that is available includes audio from most NPR programs dating back to 1995 as well as text, images and other web-only content from NPR and NPR member stations. This archive consists of over 250,000 stories that are grouped into more than 5,000 different aggregations.
 
-Access to the NPR API requires an API Key which you can get by [registering for an NPR account](http://www.npr.org/account/signup).
+Access to the NPR API requires an API Key which you can get by [registering for an NPR account](https://secure.npr.org/oauth2/login).
 
-The WordPress plugin is being developed as an Open Source plugin by NPR Digital Services. If you would like to suggest features or bug fixes, or better yet if you would like to contribute new features or bug fixes please contact Digital Services through our support page at [http://info.ds.npr.org/support.html](http://info.ds.npr.org/support.html).
+The WordPress plugin is being developed as an Open Source plugin by NPR Digital Services. If you would like to suggest features or bug fixes, or better yet if you would like to contribute new features or bug fixes please contact Digital Services through our support page at [https://info.ds.npr.org/support.html](https://info.ds.npr.org/support.html).
 
 == Installation ==
 
@@ -31,7 +31,7 @@ The WordPress plugin is being developed as an Open Source plugin by NPR Digital 
 
 = Can anyone get an NPR API Key? =
 
-That's up to NPR but you can [register for an account here](http://www.npr.org/account/signup).
+That's up to NPR but you can [register for an account here](https://secure.npr.org/oauth2/login).
 
 = Can anyone push content into the NPR API using this plugin? =
 
@@ -41,11 +41,11 @@ Push requires an Organization ID in the NPR API, which is typically given out to
 
 The best resource for general information about the NPR API is here: [https://nprsupport.desk.com/customer/en/portal/topics/783619-api/articles](https://nprsupport.desk.com/customer/en/portal/topics/783619-api/articles).
 
-There's also the documentation in the NPR API site: [http://www.npr.org/api/index.php](http://www.npr.org/api/index.php).
+There's also the documentation in the NPR API site: [https://www.npr.org/api/index.php](https://www.npr.org/api/index.php).
 
 = Is there an easy way to directly query the NPR API? =
 
-You bet, just visit the NPR Query Generator: [http://www.npr.org/api/queryGenerator.php](http://www.npr.org/api/queryGenerator.php)
+You bet, just visit the NPR Query Generator: [https://www.npr.org/api/queryGenerator.php](https://www.npr.org/api/queryGenerator.php)
 
 == Screenshots ==
 
@@ -102,7 +102,7 @@ NPR Stories having got gotten
 * Multiple Bylines for pulled stories -  When an API story has multiple bylines, we will now populate a meta field `npr_multi_byline` with a pipe (|) deliminated list of names.  If the author also has a link for thier byline then there'll be a tilde (~) separating the author's name and the link.
   - An example of data for multiple bylines:
 
-		Ari Shapiro~http://www-s2.npr.org/people/2101154/ari-shapiro|kmoylan@npr.org|Tommy Writer
+		Ari Shapiro~https://www.npr.org/people/2101154/ari-shapiro|kmoylan@npr.org|Tommy Writer
 
   - Here there are three authors for this story, Ari Shapiro (and his bio link), then "kmoylan@npr.org" and a third author "Tommy Writer". Single author stories will not be changed. (This fix came from Ryan Tainter at KERA. Thanks, Ryan!)
 
@@ -112,7 +112,7 @@ NPR Stories having got gotten
 
 * Reversed the order of images and audio that are being pushed to the NPR API.  We're now sending them in the order the file was created.
 * Mapping of media credit and agency - If you have a field that you are storing image credit and agency, you can now send these to the NPR API. In making this change we needed to expose meta fields that begin with an underscore.  So you may see more meta fields visable on the mapping page.
-* Multiple bylines are now being pushed to the NPR API if you use the plugin co-author-plus (<http://wordpress.org/plugins/co-authors-plus/>) We insert a byline row for each of the co-authors of a post when we push. You can still use a custom byline field if you want to use that along with the co-authors plugin.
+* Multiple bylines are now being pushed to the NPR API if you use the plugin co-author-plus (<https://wordpress.org/plugins/co-authors-plus/>) We insert a byline row for each of the co-authors of a post when we push. You can still use a custom byline field if you want to use that along with the co-authors plugin.
 * Retrieved story dates -  Now when you retrieve a story from the NPR API the published date for WordPress will be the date from the <storyDate> field in the NPR API. This will better allow stories to fall into their natural order when publishing from the Get Multi page. It's always possible to edit the date by hand when pulling single stories from the NPR API. Do remember though that you are contractually obligated to show the original date when rendering a story from the NPR API.
 * Retrieved story order -  When you retrieve stories from the API, if you do not include a `sort` parameter in your query, we will insure that the order of the stories is in reverse cron for any stories that have the same storyDate in the API. Often some aggregate groups in the API will publish stories with the same storyDate. Shows like Morning Edition do this often, and prior to this fix stories would appear to be published in reverse order from what the API shows.  Now if you do not include `sort` in your query, the stories with the same time will be published in the same order as the API shows them.
 * Configurable Cron interval -  When you use the Get Multi page, which fires off of wp-cron, you can now set the interval for the wp-cron to fire. This is on the Get Multi configuration page, and allows you to enter a number of minutes you want as your wp-cron interval. If you enter any thing that is not a number, or a number less than 1, we will resolve that to 60 minutes...because, well, that's a resonable interval, and the wp-cron doesn't understand 'every now and then' as an interval.
@@ -135,7 +135,7 @@ NPR Stories having got gotten
 
 = V1.3 =
 
-* Permissions - If you have created any NPR API Permissions Groups you can select which (if any) group you would like to use as your default group when pushing content to the NPR API.  Learn more about NPR API Permissions Groups here: <http://digitalservices.npr.org/post/npr-api-content-permissions-control>
+* Permissions - If you have created any NPR API Permissions Groups you can select which (if any) group you would like to use as your default group when pushing content to the NPR API.  Learn more about NPR API Permissions Groups here: <https://digitalservices.npr.org/post/npr-api-content-permissions-control>
 * Multi-Site - Cron set up and other activation tasks will now happen on every site in a multi-site configuration.
 * Cron queries - We won't try to query for any of the configured queries on the Get Multi page if the field isn't filled in with data.
 * Content and short codes - Instead of blindly removing all shortcodes from a story's content, we are now trying to let any plugins replace the shortcodes with HTML, and then if there are any leftover shortcodes (we delete those?).
@@ -152,10 +152,10 @@ This version will allow admins to configure their WordPress site to retrieve mul
 
 * From the Admin -> Settings -> NPR API Get Multi page (wp-admin/options-general.php?page=ds_npr_api_get_multi_settings) an admin can add a number of queries.
 * These query entries can contain an API ID for a single story, or an ID for a specific category, program, topic, etc.
-* The query can also contain the full query string can be created from the NPR API Query Generator: <http://www.npr.org/api/queryGenerator.php>
+* The query can also contain the full query string can be created from the NPR API Query Generator: <https://www.npr.org/api/queryGenerator.php>
 * You can also enter the URL for a story you found on npr.org.
 * The entered queries will be executed via the Wordpress cron functionality, hourly.
-* Any new stories that are available will be automatically published.  You can find a list of query filters at the npr.org's API documentation page: <http://www.npr.org/api/inputReference.php>
+* Any new stories that are available will be automatically published.  You can find a list of query filters at the npr.org's API documentation page: <https://www.npr.org/api/inputReference.php>
 * Stories retrieved from the NPR API will be created as Posts in WordPress.  Each post will have a number of meta fields associated with the post.  These meta fields will all begin with `npr_` and can be viewed on a post edit screen with Custom Fields option enabled through Screen Options. A story from the API that has a primary image defined will have that image set as the featured image of the Wordpress post.  Any bylines for the NPR Story will be stored in the meta field `npr_byline`. The list of npr_ meta fields is:
 
 		npr_api_link
@@ -176,11 +176,11 @@ This version will allow admins to configure their WordPress site to retrieve mul
 As not a lot of users have installed the V1.0 of the NPR API Plugin, there are a couple of things to keep in mind.
 
 * On the NPR API settings page (wp-admin/options-general.php?page=ds_npr_api) there are 4 fields.
-  - API KEY - This is your NPR API Key that you can get from NPR.  If you wish to push stories to the NPR API you'll need to have your key configured by NPR Digital Services.  Please contact Digital Services with a support request at <http://info.ds.npr.org//support.html>
-  - Pull URL - This is the root url for retrieving stories.  For testing purposes, you should configure this to be `http://api-s1.npr.org`. NOTE: this url should not contain a trailing slash.
-  - Push URL - Much like the pull url, this url is used to pushing stories to the NPR API. Again, for testing purposes, you can utilize NPR's staging server  at `http://api-s1.npr.org`. If you do not wish to push your content, or your NPR API has not been authorized, you should leave this field empty and the WordPress plugin will not attempt to push you content to the NPR API.
-  - Org ID - This is your organization's ID assigned by NPR.  If you don't know your Org ID, please contact Digital Services at: <http://info.ds.npr.org/support.html>
-* You can pull stories one at a time from the NPR API by using the Get NPR Stories page under admin Posts menu (wp-admin/edit.php?page=get-npr-stories). This can be story ID from the API, or the URL for the story from npr.org. For help in finding possible query options, please use the Query Generator at <http://www.npr.org/api/queryGenerator.php> Documentation is at: <http://www.npr.org/api/inputReference.php>
+  - API KEY - This is your NPR API Key that you can get from NPR.  If you wish to push stories to the NPR API you'll need to have your key configured by NPR Digital Services.  Please contact Digital Services with a support request at <https://info.ds.npr.org//support.html>
+  - Pull URL - This is the root url for retrieving stories.  For testing purposes, you should configure this to be `https://api-s1.npr.org`. NOTE: this url should not contain a trailing slash.
+  - Push URL - Much like the pull url, this url is used to pushing stories to the NPR API. Again, for testing purposes, you can utilize NPR's staging server  at `https://api-s1.npr.org`. If you do not wish to push your content, or your NPR API has not been authorized, you should leave this field empty and the WordPress plugin will not attempt to push you content to the NPR API.
+  - Org ID - This is your organization's ID assigned by NPR.  If you don't know your Org ID, please contact Digital Services at: <https://info.ds.npr.org/support.html>
+* You can pull stories one at a time from the NPR API by using the Get NPR Stories page under admin Posts menu (wp-admin/edit.php?page=get-npr-stories). This can be story ID from the API, or the URL for the story from npr.org. For help in finding possible query options, please use the Query Generator at <https://www.npr.org/api/queryGenerator.php> Documentation is at: <https://www.npr.org/api/inputReference.php>
 
 == Upgrade Notice ==
 

--- a/settings_ui.php
+++ b/settings_ui.php
@@ -24,7 +24,7 @@ function nprstory_api_options_page() {
 function nprstory_api_get_multi_options_page() {
 ?>
 	<div>
-       <div><p>Create an NPR API query (see the <a target="_" href="http://www.npr.org/api/queryGenerator.php">NPR API query generator</a>). Enter your queries into one of the rows below to have stories on that query automatically publish to your site. Please note, you do not need to include your API key to the query.  </div>
+       <div><p>Create an NPR API query (see the <a target="_" href="https://www.npr.org/api/queryGenerator.php">NPR API query generator</a>). Enter your queries into one of the rows below to have stories on that query automatically publish to your site. Please note, you do not need to include your API key to the query.  </div>
         <form action="options.php" method="post">
             <?php settings_fields( 'ds_npr_api_get_multi_settings' ); ?>
             <?php do_settings_sections( 'ds_npr_api_get_multi_settings' ); ?>

--- a/tests/test-ds-npr-api.php
+++ b/tests/test-ds-npr-api.php
@@ -12,7 +12,7 @@ class Test_DsNprApi extends WP_UnitTestCase {
 		$this->assertEquals( $option, 5 );
 
 		$option = get_option( 'ds_npr_api_pull_url' );
-		$this->assertEquals( $option, 'http://api.npr.org' );
+		$this->assertEquals( $option, 'https://api.npr.org' );
 	}
 
 	function test_nprstory_activate() {


### PR DESCRIPTION
## Changes

(edited)

- Replaces all `http:` URLs in the plugin with `https:` URLs
- Updates the regular expressions used by DS_NPR_API::load_page_hook to find the story ID
- Updates the NPRML XML namespace declaration to also use an HTTPS URL: https://github.com/npr/nprapi-wordpress/issues/45
- Replaces a few outdated NPR links in docs and readmes with correct ones, where the redirect worked in an obvious fashion:
    - Account signup pages
    - Ari Shapiro's bio

## Why

From the update document:

> With NPR.org going HTTPS, following update needs to be made in the Story API plugin for querying Story content so NPR stories can be queried by HTTPS and HTTP URLs

For https://github.com/INN/WP-DS-NPR-API/issues/11