### PR TITLE
Expand tests to modern WordPress versions and PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ language: php
 
 # PHP versions
 php:
-    - "5.3"
-    - "5.4"
-    - "5.5"
+    - "5.6"
+    - "7.0"
+    - "7.1"
+    - "7.2"
 
 # WordPress versions
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,13 +56,9 @@ matrix:
       - php: 5.6
         env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 7.0
-        env: WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-      - php: 7.0
         env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 7.0
         env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-      - php: 7.1
-        env: WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 7.1
         env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,19 @@ php:
 
 # WordPress versions
 env:
-    - WP_VERSION=3.8.14 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=3.9.12 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.0.11 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.1.11 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.2.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.3.4 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.4.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.5.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=3.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=3.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.4 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.6 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
 
-# Only test the bootstrap-unit-tests branch for now
 branches:
     only:
         - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,26 +8,65 @@ sudo: false
 language: php
 
 # PHP versions
-php:
-    - "5.6"
-    - "7.0"
-    - "7.1"
-    - "7.2"
+# php:
+#     - "5.6"
+#     - "7.0"
+#     - "7.1"
+#     - "7.2"
 
 # WordPress versions
-env:
-    - WP_VERSION=3.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=3.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.4 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.6 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+# env:
+#     - WP_VERSION=3.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.4 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.6 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+#     - WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+
+# for a breakdown of why these versions were chosen, see https://github.com/INN/WP-DS-NPR-API/issues/12#issuecomment-374730094
+matrix:
+    include:
+      - php: 5.6
+        env: WP_VERSION=3.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=3.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.4 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.6 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.0
+        env: WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.0
+        env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.0
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.1
+        env: WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.1
+        env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.1
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ language: php
 # for a breakdown of why these versions were chosen, see https://github.com/INN/WP-DS-NPR-API/issues/12#issuecomment-374730094
 matrix:
     include:
+      # PHPUnit 5
       - php: 5.6
         env: WP_VERSION=3.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 5.6
@@ -55,14 +56,17 @@ matrix:
         env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 5.6
         env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 6
       - php: 7.0
         env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 7.0
         env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 6
       - php: 7.1
         env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 7.1
         env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 7 not supported by WordPress
 
 branches:
     only:


### PR DESCRIPTION
## Changes

In `.travis.yml`, and thus in the automated tests that run on Travis CI:

- PHP versions now covered: 5.6 through 7.1 (not 7.2, for reasons explained later)
- WordPress versions now covered: 3.8 through 4.9, at the level of the latest security patch

## Why

This PR expands the versions tested because we want to make sure that the plugin is compatible with recent PHP and WordPress versions. The simple way to do that is to enumerate a list of WordPress versions and a list of PHP versions, and then run the tests at each intersection. Not only is this approach inefficient, it causes problems when old versions of WordPress include a test suite that assumes an old version of PHPUnit, which is not available when Travis CI only offers one version of PHPUnit per PHP version.

Based on research in npr/pmp-php-sdk#36,
Travis CI runs tests using the following PHPUnit versions:

- PHP 5.6: PHPUnit 5.7.23
- PHP 7: PHPUnit 6.4.3
- PHP 7.1: PHPUnit 6.4.3
- PHP 7.2: PHPUnit 7.0.2

Reasons that given versions of WordPress have tests incompatible with travis-ci.org:

1. There are PHP warnings about deprecated PHP-4-style constructors.
2. Requires PHPUnit 5 because PHPUnit 6 support was not included until WordPress 4.7.
3. Unless there's been an update since [this trac thread](https://core.trac.wordpress.org/ticket/39822), WordPress tests still assume PHPUnit 6, and Travis runs PHP 7.2 tests using PHPUnit 7

| phpunit | 5.7 | 6.4 | 6.4 | 7.0 |                 |                  |
|---------|-----|-----|-----|-----|-----------------|------------------|
| **php** | 5.6 | 7.0 | 7.1 | 7.2 |                 |                  |
| **WP**      |     |     |     |     | wp release year | then-current php |
| 3.8     |     | 1   | 1   | 1   | 2013            |                  |
| 3.9     |     | 1   | 1   | 1   | 2014            | 5.5              |
| 4.0     |     | 1   | 1   | 1   | 2014            | 5.5              |
| 4.1     |     | 1   | 1   | 1   | 2014            | 5.5              |
| 4.2     |     | 2   | 2   | 2   | 2015            | 5.6              |
| 4.3     |     | 2   | 2   | 2   | 2015            | 5.6              |
| 4.4     |     | 2   | 2   | 2   | 2015            | 7.0              |
| 4.5     |     | 2   | 2   | 2   | 2016            | 7.0              |
| 4.6     |     | 2   | 2   | 2   | 2016            | 7.0              |
| 4.7     |     | 2   | 2   | 2   | 2016            | 7.1              |
| 4.8     |     |     |     | 3   | 2017            | 7.1              |
| 4.9     |     |     |     | 3   | 2017            | 7.2              |