### PR TITLE
1.7.1: more version number bumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 release/
+vendor/

--- a/README.md
+++ b/README.md
@@ -1,18 +1,13 @@
 # NPR Story API
 
-A collection of tools for publishing from and to NPR's Story API.
+A collection of tools for publishing from and to NPR's Story API. [Find this plugin on the Wordpress.org Plugin Repository](https://wordpress.org/plugins/npr-story-api/).
 
-Contributors: nprds, inn_nerds
-
-Requires at least: 3.8.14
-
-Tested up to: 4.5.2
-
-Stable tag: 1.7
-
-License: GPLv2
-
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Contributors: nprds, inn_nerds  
+Requires at least: 3.8.14  
+Tested up to: 4.9  
+Stable tag: 1.7  
+License: GPLv2  
+License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 
 == Description ==
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A collection of tools for publishing from and to NPR's Story API. [Find this plu
 Contributors: nprds, inn_nerds  
 Requires at least: 3.8.14  
 Tested up to: 4.9  
-Stable tag: 1.7  
+Stable tag: 1.7.1  
 License: GPLv2  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 

--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: NPR Story API
  * Description: A collection of tools for reusing content from NPR.org supplied by Digital Services.
- * Version: 1.7
+ * Version: 1.7.1
  * Author: NPR Digital Services
  * License: GPLv2
 */

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: nprds, inn_nerds
 Donate link: https://www.npr.org/series/750002/support-public-radio
 Tags: npr, news, public radio, api
 Requires at least: 3.8.14
-Tested up to: 4.5.2
-Stable tag: 1.6
+Tested up to: 4.9
+Stable tag: 1.7
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: nprapi

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.npr.org/series/750002/support-public-radio
 Tags: npr, news, public radio, api
 Requires at least: 3.8.14
 Tested up to: 4.9
-Stable tag: 1.7
+Stable tag: 1.7.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: nprapi
@@ -72,6 +72,11 @@ NPR Stories having got gotten
 
 
 == Changelog ==
+
+= V1.7.1 =
+
+* Fixes version numbers in the plugin for the plugin, WordPress "tested up to", and the stable tag.
+* Does not affect plugin functionality; this is purely a WordPress.org metadata update.
 
 = V1.7 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -76,7 +76,7 @@ NPR Stories having got gotten
 = V1.7.1 =
 
 * Fixes version numbers in the plugin for the plugin, WordPress "tested up to", and the stable tag.
-* Does not affect plugin functionality; this is purely a WordPress.org metadata update.
+* This release fixes some WordPress.org metadata. For a list of new features, see the version 1.7 changelog.
 
 = V1.7 =
 


### PR DESCRIPTION
## Changes

- bumps the version number to 1.7.1 to avoid conflict with 1.7
- bumps the WordPress "tested up to:" version to 4.9
- bumps the stable plugin tag version in readme.txt — which is what wordpress.org cares about — to 1.7.1 from 1.6
- adds `vendor/` to the gitignore
- links to https://wordpress.org/plugins/npr-story-api/ from the README.md file seen on Github

## Why

Primarily to fix the "Stable tag:" metadata on WordPress.org so that the plugin would be prompted to update.