### PR TITLE
Fixes for invalid GMT offset when creating new DateTimeZone in post-edit widget

### DIFF
--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -68,17 +68,17 @@ register_deactivation_hook( NPRSTORY_PLUGIN_DIR . 'ds-npr-api.php', 'nprstory_de
 function nprstory_activation() {
 	global $wpdb;
 	if ( function_exists( 'is_multisite' ) && is_multisite() ) {
-	  // check if it is a network activation - if so, run the activation function for each blog id
-        $old_blog = $wpdb->blogid;
+		// check if it is a network activation - if so, run the activation function for each blog id
+		$old_blog = $wpdb->blogid;
 		// Get all blog ids
 		$blogids = $wpdb->get_col( $wpdb->prepare( "SELECT blog_id FROM $wpdb->blogs" ) );
 		foreach ( $blogids as $blog_id ) {
-            switch_to_blog( $blog_id );
-            nprstory_activate();
+			switch_to_blog( $blog_id );
+			nprstory_activate();
 		}
 		switch_to_blog( $old_blog );
 	} else {
-        nprstory_activate();
+		nprstory_activate();
 	}
 }
 
@@ -99,13 +99,12 @@ function nprstory_activate() {
 	if ( empty( $pull_url ) ) {
 		update_option( 'ds_npr_api_pull_url', $def_url );
 	}
-	
 }
 
 function nprstory_deactivation() {
 	global $wpdb;
 	if ( function_exists( 'is_multisite' ) && is_multisite() ) {
-	  // check if it is a network activation - if so, run the activation function for each blog id
+		// check if it is a network activation - if so, run the activation function for each blog id
 		$old_blog = $wpdb->blogid;
 		// Get all blog ids
 		$blogids = $wpdb->get_col( $wpdb->prepare( "SELECT blog_id FROM $wpdb->blogs" ) );
@@ -150,11 +149,11 @@ function nprstory_create_post_type() {
 			'labels' => array(
 				'name' => __( 'NPR Stories' ),
 				'singular_name' => __( 'NPR Story' ),
-        ),
-		'public' => true,
-		'has_archive' => true,
-		'menu_position' => 5,
-		'supports' => array( 'title', 'editor', 'thumbnail', 'custom-fields' ),
+			),
+			'public' => true,
+			'has_archive' => true,
+			'menu_position' => 5,
+			'supports' => array( 'title', 'editor', 'thumbnail', 'custom-fields' ),
 		)
 	);
 }

--- a/push_story.php
+++ b/push_story.php
@@ -706,7 +706,6 @@ function nprstory_get_datetimezone() {
 	try {
 		$return = new DateTimeZone( $offset );
 	} catch( Exception $e ) {
-		error_log(var_export( $e->getMessage(), true));
 		nprstory_error_log( $e->getMessage() );
 		$return = new DateTimeZone( '+0000' ); // The default timezone when WordPress does not have a configured timezone. This will also trigger when the gmt_offset is '0', which is the case when the GMT time is Greenwich Mean Time.
 	}

--- a/push_story.php
+++ b/push_story.php
@@ -699,7 +699,7 @@ function nprstory_get_datetimezone() {
 	if ( is_numeric( $timezone ) ) {
 		// Because PHP handles timezone offsets for this purpose in seconds,
 		// (at least, according to https://secure.php.net/manual/en/datetimezone.getoffset.php)
-		// we must convert the WordPress-stored decimal hours into seconds. THis value can be positive, negative, or zero.
+		// we must convert the WordPress-stored decimal hours into seconds. This value can be positive, negative, or zero.
 		$offset = floatval( $timezone ) * HOUR_IN_SECONDS;
 	} // It could also be '' empty string, which is a valid offset for the purposes of DateTimeZone::__construct().
 

--- a/push_story.php
+++ b/push_story.php
@@ -624,6 +624,7 @@ add_action( 'save_post', 'nprstory_save_nprone_featured');
  * @param Int $post_ID The post ID of the post we're saving
  * @since 1.7
  * @see nprstory_publish_meta_box
+ * @uses nprstory_get_datetimezone
  * @link https://en.wikipedia.org/wiki/ISO_8601
  */
 function nprstory_save_datetime( $post_ID ) {
@@ -642,7 +643,7 @@ function nprstory_save_datetime( $post_ID ) {
 	// If the post is not published and values are not set, save an empty post meta
 	if ( isset( $date ) && 'publish' === $post->status ) {
 		$timezone = get_option( 'gmt_offset' );
-		$datetime = date_create( $date, new DateTimeZone( $timezone ) );
+		$datetime = date_create( $date, nprstory_get_datetimezone() );
 		$time = explode( ':', $time );
 		$datetime->setTime( $time[0], $time[1] );
 		$value = date_format( $datetime , DATE_ATOM );
@@ -662,22 +663,55 @@ add_action( 'save_post', 'nprstory_save_datetime');
  * @param WP_Post|int $post the post ID or WP_Post object
  * @return DateTime the DateTime object created from the post expiry date
  * @see note on DATE_ATOM and DATE_ISO8601 https://secure.php.net/manual/en/class.datetime.php#datetime.constants.types
+ * @uses nprstory_get_datetimezone
  * @since 1.7
  * @todo rewrite this to use fewer queries, so it's using the WP_Post internally instead of the post ID
  */
 function nprstory_get_post_expiry_datetime( $post ) {
 	$post = ( $post instanceof WP_Post ) ? $post->ID : $post ;
 	$iso_8601 = get_post_meta( $post, '_nprone_expiry_8601', true );
-	$timezone = get_option( 'gmt_offset' );
+	$timezone = nprstory_get_datetimezone();
 
 	if ( empty( $iso_8601 ) ) {
 		// return DateTime for the publish date plus seven days
 		$future = get_the_date( DATE_ATOM, $post ); // publish date
-		return date_add( date_create( $future, new DateTimeZone( $timezone ) ), new DateInterval( 'P7D' ) );
+		return date_add( date_create( $future, $timezone ), new DateInterval( 'P7D' ) );
 	} else {
 		// return DateTime for the expiry date
-		return date_create( $iso_8601, new DateTimeZone( $timezone ) );
+		return date_create( $iso_8601, $timezone );
 	}
+}
+
+/**
+ * Helper for getting WordPress GMT offset
+ *
+ * It turns out we don't need to do anything with regards to get_option( 'timezone_string' ),
+ * because WordPress includes wp_timezone_override_offset as a default filter upon
+ * the filter pre_option_gmt_offset
+ *
+ * @since 1.7.2
+ * @link https://github.com/npr/nprapi-wordpress/issues/52
+ * @return DateTimeZone
+ */
+function nprstory_get_datetimezone() {
+	$timezone = get_option( 'gmt_offset' );
+
+	if ( is_numeric( $timezone ) ) {
+		// Because PHP handles timezone offsets for this purpose in seconds,
+		// (at least, according to https://secure.php.net/manual/en/datetimezone.getoffset.php)
+		// we must convert the WordPress-stored decimal hours into seconds. THis value can be positive, negative, or zero.
+		$offset = floatval( $timezone ) * HOUR_IN_SECONDS;
+	} // It could also be '' empty string, which is a valid offset for the purposes of DateTimeZone::__construct().
+
+	try {
+		$return = new DateTimeZone( $offset );
+	} catch( Exception $e ) {
+		error_log(var_export( $e->getMessage(), true));
+		nprstory_error_log( $e->getMessage() );
+		$return = new DateTimeZone( '+0000' ); // The default timezone when WordPress does not have a configured timezone. This will also trigger when the gmt_offset is '0', which is the case when the GMT time is Greenwich Mean Time.
+	}
+
+	return $return;
 }
 
 /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,12 +1,37 @@
 <?php
+/**
+ * PHPUnit bootstrap file
+ */
 
 $wp_tests_dir = getenv('WP_TESTS_DIR');
+if ( ! $wp_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+if ( ! file_exists( $wp_tests_dir . '/includes/functions.php' ) ) {
+	echo "Could not find $wp_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL;
+	exit( 1 );
+}
+
+// Give access to tests_add_filter() function.
 require_once $wp_tests_dir . '/includes/functions.php';
 
+/**
+ * Make sure WordPress knows the plugin should be active
+ */
 function _manually_load_environment() {
 	$plugins_to_active = array("WP-DS-NPR-API/ds-npr-api.php");
-	update_option('active_plugins', $plugins_to_active);
+	update_option( 'active_plugins', $plugins_to_active );
 }
-tests_add_filter('muplugins_loaded', '_manually_load_environment');
+tests_add_filter( 'muplugins_loaded', '_manually_load_environment' );
 
+/**
+ * Manually load the plugin being tested.
+ */
+function _manually_load_plugin() {
+	require dirname( dirname( __FILE__ ) ) . '/sample-plugin.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+// Start up the WP testing environment.
 require $wp_tests_dir . '/includes/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,7 +29,7 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_environment' );
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/sample-plugin.php';
+	require dirname( dirname( __FILE__ ) ) . '/ds-npr-api.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/test-meta-boxes.php
+++ b/tests/test-meta-boxes.php
@@ -14,7 +14,7 @@ class Test_MetaBoxes extends WP_UnitTestCase {
 
 		# Simple test of output to verify some part of the expected markup is present
 		$this->expectOutputRegex('/<div id\="ds-npr-publish-actions"/');
-		nprstory_publish_meta_box();
+		nprstory_publish_meta_box( $post );
 
 		/*
 		 * @todo:

--- a/tests/test-push_story.php
+++ b/tests/test-push_story.php
@@ -159,10 +159,14 @@ class Test_PushStory extends WP_UnitTestCase {
 		foreach ( $zones as $offset ) {
 			update_option( 'gmt_offset', $offset );
 			$DateTimeZone = nprstory_get_datetimezone();
-			$this->assertInstanceOf( DateTimeZone, $DateTimeZone, sprintf(
-				'%1$s is not an instance of DateTimeZone when DateTimeZone::__construct was called with the timezone %2$s as the wp_options option_key gmt_offset.',
-				var_export( $DateTimeZone ),
-				var_export( $offset )
+			$this->assertInstanceOf(
+				DateTimeZone,
+				$DateTimeZone,
+				sprintf(
+					'%1$s is not an instance of DateTimeZone when DateTimeZone::__construct was called with the timezone %2$s as the wp_options option_key gmt_offset.',
+					var_export( $DateTimeZone ),
+					var_export( $offset )
+				)
 			);
 		}
 

--- a/tests/test-push_story.php
+++ b/tests/test-push_story.php
@@ -160,7 +160,7 @@ class Test_PushStory extends WP_UnitTestCase {
 			update_option( 'gmt_offset', $offset );
 			$DateTimeZone = nprstory_get_datetimezone();
 			$this->assertInstanceOf(
-				DateTimeZone,
+				DateTimeZone::class,
 				$DateTimeZone,
 				sprintf(
 					'%1$s is not an instance of DateTimeZone when DateTimeZone::__construct was called with the timezone %2$s as the wp_options option_key gmt_offset.',

--- a/tests/test-push_story.php
+++ b/tests/test-push_story.php
@@ -121,4 +121,52 @@ class Test_PushStory extends WP_UnitTestCase {
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
+	function test_nprstory_get_datetimezone_all() {
+
+		/*
+		 * Get a list of time zones' UTC offsets.
+		 *
+		 * Yes, http://infiniteundo.com/post/25509354022/more-falsehoods-programmers-believe-about-time has been read.
+		 * Yes, https://secure.php.net/manual/en/datetimezone.listabbreviations.php returns some canonically ~weird~ time zones.
+		 * We'll mitigate those later in this test.
+		 */
+		$tzdata = DateTimeZone::listAbbreviations();
+		$zones = array();
+
+		// The format of $tzdata groups time zones by general zones.
+		foreach ( $tzdata as $general => $specific_zones ) {
+
+			// We want the offset of each specific zone.
+			$zones_each = wp_list_pluck( $specific_zones, 'offset' );
+
+			// Calculate the string offset format.
+			foreach ( $zones_each as $seconds ) {
+				if ( $seconds % 60 === 0 ) { // no fractional minutes
+					// no 20- or 40-minute offsets; they're valid but WordPress does not consider them.
+					if ( ( $seconds / 60 ) % 15 === 0 ) {
+						$zones[] = $seconds / 3600; // WordPress saves time zones as a decimal
+					}
+				}
+			}
+		}
+		$zones = array_unique( $zones );
+		asort( $zones );
+
+		// Other test cases
+		$zones[] = '';
+
+		// Run every single test case
+		foreach ( $zones as $offset ) {
+			update_option( 'gmt_offset', $offset );
+			$DateTimeZone = nprstory_get_datetimezone();
+			$this->assertInstanceOf( DateTimeZone, $DateTimeZone, sprintf(
+				'%1$s is not an instance of DateTimeZone when DateTimeZone::__construct was called with the timezone %2$s as the wp_options option_key gmt_offset.',
+				var_export( $DateTimeZone ),
+				var_export( $offset )
+			);
+		}
+
+		// reset
+		delete_option( 'gmt_offset' );
+	}
 }


### PR DESCRIPTION
## Changes

- Where the plugin generates a `DateTimeZone` object from the database, moves that construction into its own separate testable function `nprstory_get_datetime()`
- Includes a test for said function that iterates over the known valid GMT offsets from WordPress's database. This doesn't cover all possible GMT offsets, of which there are a ton. This covers almost every offset seen in WordPress's selector drop-down, and a few 45-minute-off timezones. It does not cover the 20- and 40-minute-off time zones. It does cover the `''` empty-string option_value of `'gmt_offset'`, which is what this plugin was tested under in the first place.

## Notes

- This does not need to check the option_value `'timezone_string'` because WordPress uses that value in the function `wp_timezone_override_offset` which is a filter upon the output of `get_option( 'gmt_offset' );`

## Why

#52 is described based on an email from Erin, and is caused by `DateTimeZone::__construct()` not accepting GMT offsets in the format that WordPress saves them in the database. WordPress saves them as decimal hours; PHP's `DateTimeZone::__construct()` seems to want the offset in seconds. I say "seems" because it's not explicitly described as such in any php.net documentation, but the [documentation for `DateTimeZone::listAbbreviations()`](https://secure.php.net/manual/en/datetimezone.listabbreviations.php) and the output of that function both describe offsets in numbers that only make sense as whole hours if the number displayed is a number of hours multiplied by `360`.

As a sample:

```
[0] => Array
        (
            [dst] => 1
            [offset] => -14400
            [timezone_id] => America/Porto_Acre
        )
```

The time zone "America/Porto_Acre" has an offset `-14400`. `-14400` divided by powers of ten doesn't seem correct. `-14400` divided by 60 is `-240`; divided by `60*60=360` is `-4`. Checking https://en.wikipedia.org/wiki/List_of_tz_database_time_zones shows that the offset for "America/Porto_Acre" is presently `-05:00`. The one-hour discrepancy between `-4` and `-05:00` is explained by "America/Porto_Acre" being subject to daylight saving time.

Fixes #52.