### PR TITLE
If the API push URL is not set, present a prompt to configure the plugin rather than no metabox

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ NPR Stories having got gotten
 
 == Changelog ==
 
+= [unreleased](https://github.com/npr/nprapi-wordpress/compare/1.7.1...HEAD) =
+
+* Fixes invalid GMT offset error when creating new DateTimeZone object in post metabox. [PR #53](https://github.com/npr/nprapi-wordpress/pull/53) for [issue #52](https://github.com/npr/nprapi-wordpress/issues/52).
+* When interacting with a site using the plugin in an unconfigured state, users will be prompted to set the NPR API Push URL. [PR #56](https://github.com/npr/nprapi-wordpress/pull/56) for [issue #51](https://github.com/npr/nprapi-wordpress/issues/51).
+
 = V1.7 =
 
 * The Story API box that appears in the post editor has been refreshed:

--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -158,18 +158,36 @@ function nprstory_create_post_type() {
 	);
 }
 
+/**
+ * Register the meta box and enqueue its scripts
+ *
+ * If the API Push URL option is not set, instead register a prompt to set it.
+ *
+ * @link https://github.com/npr/nprapi-wordpress/issues/51
+ */
 function nprstory_add_meta_boxes() {
 	$screen = get_current_screen();
 	$push_post_type = get_option( 'ds_npr_push_post_type' ) ?: 'post';
 	$push_url = get_option( 'ds_npr_api_push_url' );
-	if ( $screen->id == $push_post_type && ! empty( $push_url ) ) {
-		global $post;
-		add_meta_box(
-			'ds_npr_document_meta',
-			'NPR Story API',
-			'nprstory_publish_meta_box',
-			$push_post_type, 'side'
-		);
+	if ( $screen->id == $push_post_type ) {
+		if ( ! empty( $push_url ) ) {
+			global $post;
+			add_meta_box(
+				'ds_npr_document_meta',
+				'NPR Story API',
+				'nprstory_publish_meta_box',
+				$push_post_type, 'side'
+			);
+			add_action( 'admin_enqueue_scripts', 'nprstory_publish_meta_box_assets' );
+		} else {
+			global $post;
+			add_meta_box(
+				'ds_npr_document_meta',
+				'NPR Story API',
+				'nprstory_publish_meta_box_prompt',
+				$push_post_type, 'side'
+			);
+		}
 	}
 }
 add_action('add_meta_boxes', 'nprstory_add_meta_boxes');

--- a/meta-boxes.php
+++ b/meta-boxes.php
@@ -128,4 +128,34 @@ function nprstory_publish_meta_box_assets() {
 		true
 	);
 }
-add_action( 'admin_enqueue_scripts', 'nprstory_publish_meta_box_assets' );
+
+/**
+ * Alternate meta box output if the API Push URL option is not set
+ *
+ * Propmts the user to set that option.
+ * @link https://github.com/npr/nprapi-wordpress/issues/51
+ *
+ * @param WP_Post $post the WordPress post object.
+ * @since 1.8
+ * @see nprstory_add_options_page
+ */
+function nprstory_publish_meta_box_prompt( $post ) {
+	if ( current_user_can( 'manage_options' ) ) { // this should match the value in nprstory_add_options_page
+		printf(
+			'<p>%1$s</p>',
+			__( 'You must set the NPR Story API Push URL in the NPR Story API plugin\'s settings in order to push to the NPR Story API.', 'nprapi' )
+		);
+
+		$url = menu_page_url( 'ds_npr_api', false ); // this should match the value in nprstory_add_options_page
+		printf(
+			'<a href="%2$s" class="button button-primary button-large">%1$s</a>',
+			__( 'Configure the plugin', 'nprapi' ),
+			esc_attr( $url )
+		);
+	} else {
+		printf(
+			'<p>%1$s</p>',
+			__( 'Your site administrator must set the NPR Story API Push URL in the NPR Story API plugin\'s settings in order to push to the NPR API.', 'nprapi' )
+		);
+	}
+}

--- a/meta-boxes.php
+++ b/meta-boxes.php
@@ -143,19 +143,19 @@ function nprstory_publish_meta_box_prompt( $post ) {
 	if ( current_user_can( 'manage_options' ) ) { // this should match the value in nprstory_add_options_page
 		printf(
 			'<p>%1$s</p>',
-			__( 'You must set the NPR Story API Push URL in the NPR Story API plugin\'s settings in order to push to the NPR Story API.', 'nprapi' )
+			wp_kses_post( __( 'The NPR API plugin\'s settings must be configured to push stories to the NPR API. Instructions are <a href="https://github.com/npr/nprapi-wordpress/blob/master/docs/settings.md">here</a>.', 'nprapi' ) )
 		);
 
 		$url = menu_page_url( 'ds_npr_api', false ); // this should match the value in nprstory_add_options_page
 		printf(
 			'<a href="%2$s" class="button button-primary button-large">%1$s</a>',
-			__( 'Configure the plugin', 'nprapi' ),
+			wp_kses_post( __( 'Configure the Plugin', 'nprapi' ) ),
 			esc_attr( $url )
 		);
 	} else {
 		printf(
 			'<p>%1$s</p>',
-			__( 'Your site administrator must set the NPR Story API Push URL in the NPR Story API plugin\'s settings in order to push to the NPR API.', 'nprapi' )
+			wp_kses_post( __( 'Your site administrator must set the NPR Story API Push URL in the NPR Story API plugin\'s settings in order to push to the NPR API.', 'nprapi' ) )
 		);
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,7 @@ NPR Stories having got gotten
 = [unreleased](https://github.com/npr/nprapi-wordpress/compare/1.7.1...HEAD) =
 
 * Fixes invalid GMT offset error when creating new DateTimeZone object in post metabox. [PR #53](https://github.com/npr/nprapi-wordpress/pull/53) for [issue #52](https://github.com/npr/nprapi-wordpress/issues/52).
+* When interacting with a site using the plugin in an unconfigured state, users will be prompted to set the NPR API Push URL. [PR #56](https://github.com/npr/nprapi-wordpress/pull/56) for [issue #51](https://github.com/npr/nprapi-wordpress/issues/51).
 
 = V1.7.1 =
 

--- a/settings.php
+++ b/settings.php
@@ -9,6 +9,8 @@ require_once( NPRSTORY_PLUGIN_DIR . 'settings_ui.php' );
 
 /**
  * add the options page
+ *
+ * @see nprstory_publish_meta_box_prompt
  */
 function nprstory_add_options_page() {
     add_options_page( 'NPR API', 'NPR API', 'manage_options', 'ds_npr_api', 'nprstory_api_options_page' );


### PR DESCRIPTION
## Changes

If the plugin is enabled and no API push URL is set, rather than silently displaying no metabox, this changeset displays a prompt to the metabox-viewing user to configure the plugin.

The relevant settings page in the plugin is limited to users with the `manage_options` capability, so for users who don't have that capability, the following metabox is shown:

<img width="304" alt="screen shot 2018-09-21 at 5 55 30 pm" src="https://user-images.githubusercontent.com/1754187/45907834-9cb43f00-bdc7-11e8-9458-746a572f5e67.png">

Users with the `manage_options` capability are given a link to the appropriate settings page:

<img width="292" alt="screen shot 2018-09-21 at 5 55 43 pm" src="https://user-images.githubusercontent.com/1754187/45907861-b2c1ff80-bdc7-11e8-8230-fdccdd249e68.png">

The settings page is unchanged:

<img width="849" alt="screen shot 2018-09-21 at 5 56 50 pm" src="https://user-images.githubusercontent.com/1754187/45907868-c0778500-bdc7-11e8-94ed-24349c7986d0.png">


## Why

For https://github.com/npr/nprapi-wordpress/issues/51:

> Just updated to the Wordpress API plugin version that was just released and I do not have a box anywhere for NPROne. I have looked in the documentation and that box is not available on my screen or options. What happened?

## Questions:

- [x] Does this affect tests? (This is @benlk's problem)
- [x] Does the text in the meta box need to be revised?
- [x] Are there any changes that need to be made to the settings page?
- [x] Are there any parts of the plugin documentation outside of WordPress that need to be changed?