### PR TITLE
Resolve problems pushing to and pulling from Story API

### DIFF
--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -334,7 +334,7 @@ class NPRAPIWordpress extends NPRAPI {
                             }
 
                             // do the validation and storage stuff
-                            require_once( ABSPATH . 'wp-admin/includes/media.php'); // needed for media_handle_sideload during cron
+                            require_once( ABSPATH . 'wp-admin/includes/image.php'); // needed for wp_read_image_metadata used by media_handle_sideload during cron
                             $id = media_handle_sideload( $file_array, $post_id, $image->title->value );
                             // If error storing permanently, unlink
                             if ( is_wp_error($id) ) {

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -334,6 +334,7 @@ class NPRAPIWordpress extends NPRAPI {
                             }
 
                             // do the validation and storage stuff
+                            require_once( ABSPATH . 'wp-admin/includes/media.php'); // needed for media_handle_sideload during cron
                             $id = media_handle_sideload( $file_array, $post_id, $image->title->value );
                             // If error storing permanently, unlink
                             if ( is_wp_error($id) ) {

--- a/get_stories.php
+++ b/get_stories.php
@@ -9,6 +9,11 @@ require_once( NPRSTORY_PLUGIN_DIR . 'classes/NPRAPIWordpress.php');
 class DS_NPR_API {
 	var $created_message = '';
 
+	/**
+	 * What is the post type that pulled stories should be created as?
+	 *
+	 * @return string The post type
+	 */
 	public static function nprstory_get_pull_post_type() {
 		$pull_post_type = get_option( 'ds_npr_pull_post_type' );
 		if ( empty( $pull_post_type ) ) {
@@ -17,6 +22,9 @@ class DS_NPR_API {
 		return $pull_post_type;
 	}
 
+	/**
+	 * The cron job to pull stories from the API
+	 */
 	public static function nprstory_cron_pull() {
 		// here we should get the list of IDs/full urls that need to be checked hourly
 		//because this is run on cron, and may be fired off by an non-admin, we need to load a bunch of stuff
@@ -79,7 +87,10 @@ class DS_NPR_API {
 		}
 	}
 
-    function load_page_hook() {
+	/**
+	 * Function to convert an alleged NPR story URL or ID into a story ID, then request it
+	 */
+    public function load_page_hook() {
 		// find the input that is allegedly a story id
 		// We validate these later
         if ( isset( $_POST ) && isset( $_POST[ 'story_id' ] ) ) {
@@ -156,16 +167,22 @@ class DS_NPR_API {
         }
     }
 
-    function __construct() {
+	/**
+	 * Class constructor that hooks up the menu and the "Get NPR Stories" page action.
+	 */
+    public function __construct() {
         if ( ! is_admin() ) {
             return;
         }
         add_action( 'admin_menu', array( &$this, 'admin_menu' ) );
-        add_action( 'load-posts_page_get-npr-stories', array( 'DS_NPR_API', 'load_page_hook' ) );
+        add_action( 'load-posts_page_get-npr-stories', array( $this, 'load_page_hook' ) );
     }
 
-    function admin_menu() {
-        add_posts_page( 'Get NPR DS Stories', 'Get NPR Stories', 'edit_posts', 'get-npr-stories',   'nprstory_get_stories' );
+	/**
+	 * Register the admin menu for "Get NPR Stories"
+	 */
+    public function admin_menu() {
+        add_posts_page( 'Get NPR Stories', 'Get NPR Stories', 'edit_posts', 'get-npr-stories',   'nprstory_get_stories' );
     }
 
 }

--- a/get_stories.php
+++ b/get_stories.php
@@ -129,7 +129,7 @@ class DS_NPR_API {
 		}
 
 		// Don't do anything if $story_id isn't an ID
-		if ( is_numeric( $story_id ) ) {
+		if ( isset( $story_id ) && is_numeric( $story_id ) ) {
 			// start the API class
             // todo: check that the API key is actually set
             $api = new NPRAPIWordpress();

--- a/push_story.php
+++ b/push_story.php
@@ -96,7 +96,12 @@ function nprstory_api_delete ( $post_ID ) {
 	}
 
 	$api_id_meta = get_post_meta( $post_ID, NPR_STORY_ID_META_KEY );
-	$api_id = $api_id_meta[0];
+	if ( isset( $api_id_meta[0] ) ) {
+		$api_id = $api_id_meta[0];
+	} else {
+		$api_id = null;
+	}
+
 	$post = get_post( $post_ID );
 	//if the push url isn't set, don't even try to delete.
 	$push_url = get_option( 'ds_npr_api_push_url' );

--- a/push_story.php
+++ b/push_story.php
@@ -126,7 +126,7 @@ function nprstory_api_delete ( $post_ID ) {
  * Register nprstory_npr_push and nprstory_npr_delete on appropriate hooks
  * this is where the magic happens
  */
-if ( isset( $_POST['ds_npr_update_push'] ) ) {
+if ( isset( $_POST['send_to_api'] ) ) {
 	// No need to validate the ds_npr_update_push contents; we're checking only for its existence
 	// permissions check is handled by nprstory_api_push
 	add_action( 'save_post', 'nprstory_api_push', 10, 2 );

--- a/push_story.php
+++ b/push_story.php
@@ -452,7 +452,7 @@ function nprstory_get_push_post_type() {
 }
 
 function nprstory_get_permission_groups(){
-    $perm_groups = '';
+	$perm_groups = array();
 	//query the API for the lists for this org.
 	$perm_url = get_option( 'ds_npr_api_push_url' ) . '/orgs/' . get_option( 'ds_npr_api_org_id' ) . '/groups' . '?apiKey=' . get_option('ds_npr_api_key');
 	$http_result = wp_remote_get( $perm_url );

--- a/readme.txt
+++ b/readme.txt
@@ -75,8 +75,11 @@ NPR Stories having got gotten
 
 = [unreleased](https://github.com/npr/nprapi-wordpress/compare/1.7.1...HEAD) =
 
+* Fixes issue preventing pushing to the API, introduced in V1.7. [PR #60](https://github.com/npr/nprapi-wordpress/pull/60) for [issue #57](https://github.com/npr/nprapi-wordpress/issues/57).
+* Fixes issue where images were not properly sideloaded. [PR #60](https://github.com/npr/nprapi-wordpress/pull/60) for [issue #59](https://github.com/npr/nprapi-wordpress/issues/59).
 * Fixes invalid GMT offset error when creating new DateTimeZone object in post metabox. [PR #53](https://github.com/npr/nprapi-wordpress/pull/53) for [issue #52](https://github.com/npr/nprapi-wordpress/issues/52).
 * When interacting with a site using the plugin in an unconfigured state, users will be prompted to set the NPR API Push URL. [PR #56](https://github.com/npr/nprapi-wordpress/pull/56) for [issue #51](https://github.com/npr/nprapi-wordpress/issues/51).
+* Miscellaneous code quality improvements.
 
 = V1.7.1 =
 

--- a/settings.php
+++ b/settings.php
@@ -173,7 +173,7 @@ function nprstory_api_query_publish_callback($i) {
 		echo $option_string;
 	}
 	$option_string .= wp_nonce_field( 'nprstory_nonce_ds_npr_query_publish_' . $i, 'nprstory_nonce_ds_npr_query_publish_' . $i . '_name', true, false );
-    echo "</select> </div><p><hr></p>";
+    echo "</select> </div>";
 }
 
 function nprstory_api_query_callback( $i ) {

--- a/tests/test-get_stories.php
+++ b/tests/test-get_stories.php
@@ -47,7 +47,7 @@ class Test_DS_NPR_API_Class extends WP_UnitTestCase {
 		# Re-create the $test_obj after setting admin context
 		$test_obj = new DS_NPR_API;
 
-		$this->assertTrue( (bool) has_action( 'load-posts_page_get-npr-stories', array( 'DS_NPR_API', 'load_page_hook' ) ) );
+		$this->assertTrue( (bool) has_action( 'load-posts_page_get-npr-stories', array( $test_obj, 'load_page_hook' ) ) );
 		$this->assertTrue( (bool) has_action( 'admin_menu', array( &$test_obj, 'admin_menu' ) ) );
 
 		# Restore globals


### PR DESCRIPTION
## Changes

This is a wrap-up of miscellaneous errors noticed when diagnosing problems pushing to the API, documented in #57.

- Fixes issue where action used to push posts to the API was not running, because of a missed spot in https://github.com/npr/nprapi-wordpress/pull/47 identified in #57 
- Fixes issue where images were not properly sideloaded when pulling from the API, identified in #59 
- Removes duplicate `<hr/>` seen in the query-based fetch settings page "NPR API Get Multi", which was between the "Publish Stories X" and "Add Tags X" settings.
- Fixes an "undefined offset" PHP notice that occurred when attempting to delete a post from the API when the post had no API ID.
- Fixes an "undefined variable" PHP notice that occurs when loading the "Get NPR Stories" page without a post specified
- Fixes a "Non-static method DS_NPR_API::load_page_hook() should not be called statically" PHP notice that appears on the "Get NPR Stories" page — because the method was hooked incorrectly. And changes a test to match.
- Fixes an "Uncaught Error: Cannot use string offset as an array" error in the plugin settings page when checking API permissions. https://github.com/npr/nprapi-wordpress/issues/57#issuecomment-424903460

## Why

Prevents a couple issues when pushing or pulling posts from the API.