### PR TITLE
import externalAssets and htmlAssets from a story into postmeta

### DIFF
--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -244,6 +244,34 @@ class NPRAPIWordpress extends NPRAPI {
                         $metas[NPR_AUDIO_META_KEY] = implode( ',', $mp3_array );
                         $metas[NPR_AUDIO_M3U_META_KEY] = implode( ',', $m3u_array );
                     }
+                    //get exernal assets like youtube
+                    if (isset($story->externalAsset) ) {
+                      $oembeds_array = array();
+                      if (isset($story->externalAsset->type)) {
+                        $oembeds_array[] = $story->externalAsset;
+                      } else {
+                        // sometimes there are multiple objects
+                        foreach ( (array) $story->externalAsset as $extasset ) {
+                          if (isset($extasset->type)) {
+                            $oembeds_array[] = $extasset;
+                          }
+                        }
+                      }
+                      // parse those external assets into sub-arrays by type
+                      foreach ($oembeds_array as $embed) {
+                        if (!empty($embed->type)) {
+                          $embed_type = strtolower($embed->type);
+                          unset($embed->type);
+                          unset($embed->id);
+                          $translated_embed = array();
+                          foreach ( (array) $embed as $k => $v) {
+                            $translated_embed[$k] = $v->value;
+                          }
+                          $metas[NPR_OEMBED_META_KEY_PREFIX . $embed_type][] = $translated_embed;
+                        }
+                      }                     
+                    }
+
                     if ( $existing ) {
                         $created = false;
                         $args[ 'ID' ] = $existing->ID;

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -272,6 +272,23 @@ class NPRAPIWordpress extends NPRAPI {
                       }                     
                     }
 
+                    // get htmlAssets -- typically interactives -- and append to the story body
+                    if (isset($story->htmlAsset) ) {
+                      $htmls_array = array();
+                      if (isset($story->htmlAsset->id)) {
+                        $story->body .= $story->htmlAsset->value;
+                      } else {
+                        // sometimes there are multiple objects
+                        foreach ( (array) $story->htmlAsset as $hasset ) {
+                          if (isset($hasset->id)) {
+                            $story->body .= $hasset->value;
+                          }
+                        }
+                      }
+                    }
+
+
+
 
                     if ( $existing ) {
                         $created = false;

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -273,20 +273,20 @@ class NPRAPIWordpress extends NPRAPI {
                     }
 
                     // get htmlAssets -- typically interactives -- and append to the story body
+                    $html_assets = '';
                     if (isset($story->htmlAsset) ) {
-                      $htmls_array = array();
                       if (isset($story->htmlAsset->id)) {
-                        $story->body .= $story->htmlAsset->value;
+                        $html_assets .= $story->htmlAsset->value;
                       } else {
                         // sometimes there are multiple objects
                         foreach ( (array) $story->htmlAsset as $hasset ) {
                           if (isset($hasset->id)) {
-                            $story->body .= $hasset->value;
+                            $html_assets .= $hasset->value;
                           }
                         }
                       }
                     }
-
+                    $metas[NPR_HTML_ASSETS_META_KEY] = $html_assets;
 
 
 

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -244,7 +244,7 @@ class NPRAPIWordpress extends NPRAPI {
                         $metas[NPR_AUDIO_META_KEY] = implode( ',', $mp3_array );
                         $metas[NPR_AUDIO_M3U_META_KEY] = implode( ',', $m3u_array );
                     }
-                    //get exernal assets like youtube
+                    //get external assets like youtube
                     if (isset($story->externalAsset) ) {
                       $oembeds_array = array();
                       if (isset($story->externalAsset->type)) {
@@ -271,6 +271,7 @@ class NPRAPIWordpress extends NPRAPI {
                         }
                       }                     
                     }
+
 
                     if ( $existing ) {
                         $created = false;

--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -32,6 +32,7 @@ define( 'NPR_BYLINE_META_KEY', 'npr_byline' );
 define( 'NPR_BYLINE_LINK_META_KEY', 'npr_byline_link' );
 define( 'NPR_MULTI_BYLINE_META_KEY', 'npr_multi_byline' );
 define( 'NPR_IMAGE_GALLERY_META_KEY', 'npr_image_gallery');
+define( 'NPR_HTML_ASSETS_META_KEY', 'npr_html_assets');
 define( 'NPR_AUDIO_META_KEY', 'npr_audio');
 define( 'NPR_AUDIO_M3U_META_KEY', 'npr_audio_m3u');
 define( 'NPR_PUB_DATE_META_KEY', 'npr_pub_date');

--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -43,6 +43,8 @@ define( 'NPR_IMAGE_CREDIT_META_KEY', 'npr_image_credit');
 define( 'NPR_IMAGE_AGENCY_META_KEY', 'npr_image_agency');
 define( 'NPR_IMAGE_CAPTION_META_KEY', 'npr_image_caption');
 
+define( 'NPR_OEMBED_META_KEY_PREFIX', 'npr_ds_oembeds_');
+
 define( 'NPR_PUSH_STORY_ERROR', 'npr_push_story_error');
 
 define( 'NPR_MAX_QUERIES', 10 );


### PR DESCRIPTION
The "externalAssets" at the end of many stories are oembed links for YouTube and Twitter (possibly others) that are referred to in the story.  Parsing those into arrays and saving them into appropriate postmeta eg 'npr_ds_oembeds_twitter'/'npr_ds_oembeds_youtube' allows them to be integrated into the WordPress posts as appropriate.   They could then be retrieved like so:

`$tweets = get_post_custom('npr_ds_oembeds_twitter);
foreach ($tweets as $tweet) {
echo (wp_oembed_get($tweet['url']));
}`
YouTube videos are importable the same way, expect replace 'twitter' with 'youtube' in the example.

Similarly, the "htmlAssets" are standalone elements -- typically a div and some javascript that generate an interactive map or table.   Again, this PR saves those into a postmeta with the key 'npr_html_assets' where they could be appended to the story in WordPress, eg

`$htmlassets = get_post_custom('npr_html_assets');
foreach ($htmlassets as $htmlasset) {
echo ($htmlasset);
}`

This pull request only adds functionality and does not alter any current functionality.