### PR TITLE
Use NPR layout to format the post body in WordPress 

### DIFF
--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -244,6 +244,34 @@ class NPRAPIWordpress extends NPRAPI {
                         $metas[NPR_AUDIO_META_KEY] = implode( ',', $mp3_array );
                         $metas[NPR_AUDIO_M3U_META_KEY] = implode( ',', $m3u_array );
                     }
+                    //get exernal assets like youtube
+                    if (isset($story->externalAsset) ) {
+                      $oembeds_array = array();
+                      if (isset($story->externalAsset->type)) {
+                        $oembeds_array[] = $story->externalAsset;
+                      } else {
+                        // sometimes there are multiple objects
+                        foreach ( (array) $story->externalAsset as $extasset ) {
+                          if (isset($extasset->type)) {
+                            $oembeds_array[] = $extasset;
+                          }
+                        }
+                      }
+                      // parse those external assets into sub-arrays by type
+                      foreach ($oembeds_array as $embed) {
+                        if (!empty($embed->type)) {
+                          $embed_type = strtolower($embed->type);
+                          unset($embed->type);
+                          unset($embed->id);
+                          $translated_embed = array();
+                          foreach ( (array) $embed as $k => $v) {
+                            $translated_embed[$k] = $v->value;
+                          }
+                          $metas[NPR_OEMBED_META_KEY_PREFIX . $embed_type][] = $translated_embed;
+                        }
+                      }                     
+                    }
+
                     if ( $existing ) {
                         $created = false;
                         $args[ 'ID' ] = $existing->ID;

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -102,6 +102,7 @@ class NPRAPIWordpress extends NPRAPI {
 		if ( empty( $pull_post_type ) ) {
 			$pull_post_type = 'post';
 		}
+    $use_npr_layout = !empty(get_option( 'dp_npr_query_use_layout' )) ? TRUE : FALSE;
 
 	    $post_id = null;
 

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -245,50 +245,6 @@ class NPRAPIWordpress extends NPRAPI {
                         $metas[NPR_AUDIO_META_KEY] = implode( ',', $mp3_array );
                         $metas[NPR_AUDIO_M3U_META_KEY] = implode( ',', $m3u_array );
                     }
-                    //get external assets like youtube
-                    if (isset($story->externalAsset) ) {
-                      $oembeds_array = array();
-                      if (isset($story->externalAsset->type)) {
-                        $oembeds_array[] = $story->externalAsset;
-                      } else {
-                        // sometimes there are multiple objects
-                        foreach ( (array) $story->externalAsset as $extasset ) {
-                          if (isset($extasset->type)) {
-                            $oembeds_array[] = $extasset;
-                          }
-                        }
-                      }
-                      // parse those external assets into sub-arrays by type
-                      foreach ($oembeds_array as $embed) {
-                        if (!empty($embed->type)) {
-                          $embed_type = strtolower($embed->type);
-                          unset($embed->type);
-                          unset($embed->id);
-                          $translated_embed = array();
-                          foreach ( (array) $embed as $k => $v) {
-                            $translated_embed[$k] = $v->value;
-                          }
-                          $metas[NPR_OEMBED_META_KEY_PREFIX . $embed_type][] = $translated_embed;
-                        }
-                      }                     
-                    }
-
-                    // get htmlAssets -- typically interactives -- and append to the story body
-                    $html_assets = '';
-                    if (isset($story->htmlAsset) ) {
-                      if (isset($story->htmlAsset->id)) {
-                        $html_assets .= $story->htmlAsset->value;
-                      } else {
-                        // sometimes there are multiple objects
-                        foreach ( (array) $story->htmlAsset as $hasset ) {
-                          if (isset($hasset->id)) {
-                            $html_assets .= $hasset->value;
-                          }
-                        }
-                      }
-                    }
-                    $metas[NPR_HTML_ASSETS_META_KEY] = $html_assets;
-
 
 
                     if ( $existing ) {

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -840,40 +840,54 @@ class NPRAPIWordpress extends NPRAPI {
               case 'staticHtml':
                 if (!empty($htmlAssets[$reference])) {
                   $body_with_layout .= $htmlAssets[$reference] . "\n\n";
+                  $returnary['has_external'] = TRUE;
+                  if (strpos($htmlAssets[$reference], 'jwplayer.com')) {
+                    $returnary['has_video'] = TRUE;
+                  }
                 }
                 break;
               case 'externalAsset':
                 if (!empty($externalAssets[$reference])) {
-                  $body_with_layout .= $externalAssets[$reference]['url'] . "\n";
-                  if (!empty( (string)$externalAssets[$reference]['credit'])) {
-                    $body_with_layout .= "<cite>" . (string) $externalAssets[$reference]['credit'] . "</cite>\n";
+                  $figclass = "wp-block-embed";
+                  if (!empty( (string)$externalAssets[$reference]['type']) && strtolower((string)$externalAssets[$reference]['type']) == 'youtube') {
+                    $returnary['has_video'] = TRUE;
+                    $figclass .= " is-type-video";
                   }
-                  if (!empty( (string)$externalAssets[$reference]['caption'])) {
-                    $body_with_layout .= "<p>" . (string) $externalAssets[$reference]['caption'] . "</p>\n";
+                  $fightml = "<figure class=\"$figclass\"><div class=\"wp-block-embed__wrapper\">";
+                  $fightml .=  "\n" . $externalAssets[$reference]['url'] . "\n";
+                  $figcaption = '';
+                  if (!empty( (string)$externalAssets[$reference]['credit']) || !empty( (string)$externalAssets[$reference]['caption'] ) ) {
+                    if (!empty( trim((string)$externalAssets[$reference]['credit']))) {
+                      $figcaption .= "<cite>" . trim((string) $externalAssets[$reference]['credit']) . "</cite>";
+                    }
+                    if (!empty( (string)$externalAssets[$reference]['caption'])) {
+                      $figcaption .= trim((string) $externalAssets[$reference]['caption']);
+                    }
+                    $figcaption = !empty($figcaption) ? "<figcaption>$figcaption</figcaption>" : "";
                   }
-                  $body_with_layout .= "\n";
+                  $fightml .= "</div>$figcaption</figure>\n";
+                  $body_with_layout .= $fightml;
                 }
                 break;
               case 'image':
                 if (!empty($storyimages[$reference])) {
-                  $figclass="npr-featured-image";
+                  $figclass = "wp-block-image size-large"; 
                   $thisimg = $storyimages[$reference];
                   $fightml = !empty( (string)$thisimg['image_url']) ? '<img src="' . (string)$thisimg['image_url'] . '"' : '';
-                  $thiscaption = (string)$thisimg['caption'];
+                  $thiscaption = !empty(trim( (string)$thisimg['caption'] )) ? trim( (string)$thisimg['caption'] ) : '';
                   $fightml .= (!empty($fightml) && !empty( $thiscaption)) ? ' alt="' . $thiscaption . '"' : '';
                   $fightml .= !empty($fightml) ? '>' : '';
-                  $figcaption = (!empty($fightml) && !empty( $thiscaption)) ? '<figcaption>' . $thiscaption  : '';
-                  if (!empty($figcaption)) {
-                    $cites = '';
-                    foreach (array('producer', 'provider', 'copyright') as $item) {
-                      $thisitem = (string)$thisimg[$item];
-                      if (!empty($thisitem)) {
-                        $cites .= !empty($cites) ? ' | ' . $thisitem : $thisitem;
-                      }
+                  $figcaption = (!empty($fightml) && !empty( $thiscaption)) ? $thiscaption  : '';
+                  $cites = '';
+                  foreach (array('producer', 'provider', 'copyright') as $item) {
+                    $thisitem = trim( (string)$thisimg[$item] );
+                    if (!empty($thisitem)) {
+                      $cites .= !empty($cites) ? ' | ' . $thisitem : $thisitem;
                     }
-                    $figcaption .= !empty($cites) ? "<cite>$cites</cite>" : '';
-                  } 
-                  $figcapton .= !empty($figcaption) ? '</figcaption>' : '';
+                  }
+                  $cites = !empty($cites) ? "<cite>$cites</cite>" : '';
+                  $thiscaption .= $cites;
+                  $figcaption = (!empty($fightml) && !empty( $thiscaption)) ? "<figcaption>$thiscaption</figcaption>"  : '';
                   $fightml .= (!empty($fightml) && !empty($figcaption)) ? $figcaption : '';
                   $body_with_layout .= (!empty($fightml)) ? "<figure class=\"$figclass\">$fightml</figure>\n\n" : ''; 
                 }

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -272,6 +272,23 @@ class NPRAPIWordpress extends NPRAPI {
                       }                     
                     }
 
+                    // get htmlAssets -- typically interactives -- and append to the story body
+                    if (isset($story->htmlAsset) ) {
+                      $htmls_array = array();
+                      if (isset($story->htmlAsset->id)) {
+                        $story->body .= $story->htmlAsset->value;
+                      } else {
+                        // sometimes there are multiple objects
+                        foreach ( (array) $story->htmlAsset as $hasset ) {
+                          if (isset($hasset->id)) {
+                            $story->body .= $hasset->value;
+                          }
+                        }
+                      }
+                    }
+
+
+
 
                     if ( $existing ) {
                         $created = false;

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -280,7 +280,7 @@ class NPRAPIWordpress extends NPRAPI {
 	                 * @param bool $created true if not pre-existing, false otherwise
 	                 */
 
-                  if ($use_npr_layout) {
+                  if ($npr_has_layout) {
                     // keep WP from stripping content from NPR posts
                     kses_remove_filters();
                   }
@@ -289,7 +289,7 @@ class NPRAPIWordpress extends NPRAPI {
 
 	                $post_id = wp_insert_post( $args );
 
-                  if ($use_npr_layout) {
+                  if ($npr_has_layout) {
                     // re-enable the built-in content stripping
                     kses_init_filters();
                   }
@@ -314,7 +314,7 @@ class NPRAPIWordpress extends NPRAPI {
                         foreach ( (array) $story->image as $image ) {
 
                             // only sideload the primary image if using the npr layout
-                            if ( ($image->type != 'primary') && $use_npr_layout ) {
+                            if ( ($image->type != 'primary') && $npr_has_layout ) {
                               continue;
                             }
 
@@ -474,7 +474,7 @@ class NPRAPIWordpress extends NPRAPI {
 	                 * @param NPRMLEntity $story Story object created during import
 	                 */
 
-                  if ($use_npr_layout) {
+                  if ($npr_has_layout) {
                     // keep WP from stripping content from NPR posts
                     kses_remove_filters();
                   }
@@ -483,7 +483,7 @@ class NPRAPIWordpress extends NPRAPI {
 
 	                $post_id = wp_insert_post( $args );
 
-                  if ($use_npr_layout) {
+                  if ($npr_has_layout) {
                     // re-enable content stripping
                     kses_init_filters();
                   }

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -238,6 +238,8 @@ class NPRAPIWordpress extends NPRAPI {
                         NPR_PUB_DATE_META_KEY        => $story->pubDate->value,
                         NPR_STORY_DATE_MEATA_KEY     => $story->storyDate->value,
                         NPR_LAST_MODIFIED_DATE_KEY   => $story->lastModifiedDate->value,
+                        NPR_STORY_HAS_LAYOUT_META_KEY => $npr_has_layout,
+                        NPR_STORY_HAS_VIDEO_META_KEY => $npr_has_video,
                     );
                     //get audio
                     if ( isset($story->audio) ) {

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -275,9 +275,20 @@ class NPRAPIWordpress extends NPRAPI {
 	                 * @param NPRMLEntity $story Story object created during import
 	                 * @param bool $created true if not pre-existing, false otherwise
 	                 */
+
+                  if ($use_npr_layout) {
+                    // keep WP from stripping content from NPR posts
+                    kses_remove_filters();
+                  }
+
 	                $args = apply_filters( 'npr_pre_insert_post', $args, $post_id, $story, $created );
 
 	                $post_id = wp_insert_post( $args );
+
+                  if ($use_npr_layout) {
+                    // re-enable the built-in content stripping
+                    kses_init_filters();
+                  }
 
                     //now that we have an id, we can add images
                     //this is the way WP seems to do it, but we couldn't call media_sideload_image or media_ because that returned only the URL
@@ -452,9 +463,20 @@ class NPRAPIWordpress extends NPRAPI {
 	                 * @param int $post_id Post ID or NULL if no post ID.
 	                 * @param NPRMLEntity $story Story object created during import
 	                 */
+
+                  if ($use_npr_layout) {
+                    // keep WP from stripping content from NPR posts
+                    kses_remove_filters();
+                  }
+
 	                $args = apply_filters( 'npr_pre_update_post', $args, $post_id, $story );
 
 	                $post_id = wp_insert_post( $args );
+
+                  if ($use_npr_layout) {
+                    // re-enable content stripping
+                    kses_init_filters();
+                  }
                 }
 
                 //set categories for story

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -769,7 +769,7 @@ class NPRAPIWordpress extends NPRAPI {
                     continue;
                   }
                   $image_url = $crop->src;
-                  if ($crop->type == 'custom' || ((int)$crop->height > (int)$crop->width)) {
+                  if ($crop->type == 'custom' && ((int)$crop->height > (int)$crop->width)) {
                     $is_portrait = TRUE;
                   }
                   break;

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -781,8 +781,8 @@ class NPRAPIWordpress extends NPRAPI {
               // add resizing to any npr-hosted image
               if (strpos($image_url, 'media.npr.org')) {
                 // remove any existing querystring 
-                if (strpos($image_url)) {
-                  $image_url = substr($image_url, strpos($image_url, 0, '?'));
+                if (strpos($image_url, '?')) {
+                  $image_url = substr($image_url, 0, strpos($image_url, '?'));
                 }
                 $image_url .= !$is_portrait ? '?s=6' : '?s=12';
               }             

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -273,20 +273,20 @@ class NPRAPIWordpress extends NPRAPI {
                     }
 
                     // get htmlAssets -- typically interactives -- and append to the story body
+                    $html_assets = '';
                     if (isset($story->htmlAsset) ) {
-                      $htmls_array = array();
                       if (isset($story->htmlAsset->id)) {
-                        $story->body .= $story->htmlAsset->value;
+                        $html_assets .= $story->htmlAsset->value;
                       } else {
                         // sometimes there are multiple objects
                         foreach ( (array) $story->htmlAsset as $hasset ) {
                           if (isset($hasset->id)) {
-                            $story->body .= $hasset->value;
+                            $html_assets .= $hasset->value;
                           }
                         }
                       }
                     }
-
+                    $metas[NPR_HTML_ASSETS_META_KEY] = $html_assets;
 
 
 

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -769,7 +769,12 @@ class NPRAPIWordpress extends NPRAPI {
               if ( ! empty( $image->enlargement ) ) {
                 $image_url = $image->enlargement->src;
               }
-              if ( ! empty( $image->crop ) && is_array( $image->crop ) ) {
+              if ( ! empty( $image->crop )) {
+                if (!is_array( $image->crop ) ) {
+                  $cropobj = $image->crop;
+                  unset($image->crop);
+                  $image->crop = array($cropobj); 
+                }
                 foreach ( $image->crop as $crop ) {
                   if (empty($crop->primary)) {
                     continue;

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -312,6 +312,12 @@ class NPRAPIWordpress extends NPRAPI {
                             $attached_images = get_children( $image_args );
                         }	
                         foreach ( (array) $story->image as $image ) {
+
+                            // only sideload the primary image if using the npr layout
+                            if ( ($image->type != 'primary') && $use_npr_layout ) {
+                              continue;
+                            }
+
                             $image_url = '';
 		        		    //check the <enlargement> and then the crops, in this order "enlargement", "standard"  if they don't exist, just get the image->src
                             if ( ! empty( $image->enlargement ) ) {

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -244,7 +244,7 @@ class NPRAPIWordpress extends NPRAPI {
                         $metas[NPR_AUDIO_META_KEY] = implode( ',', $mp3_array );
                         $metas[NPR_AUDIO_M3U_META_KEY] = implode( ',', $m3u_array );
                     }
-                    //get exernal assets like youtube
+                    //get external assets like youtube
                     if (isset($story->externalAsset) ) {
                       $oembeds_array = array();
                       if (isset($story->externalAsset->type)) {
@@ -271,6 +271,7 @@ class NPRAPIWordpress extends NPRAPI {
                         }
                       }                     
                     }
+
 
                     if ( $existing ) {
                         $created = false;

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -865,7 +865,21 @@ class NPRAPIWordpress extends NPRAPI {
                   $body_with_layout .= $fightml;
                 }
                 break;
-              case 'image':
+              default:
+              // handles both 'list' and 'image' since it will reset the type and then assign the reference 
+                if ($element['type'] == 'list') {
+                  foreach ($storyimages as $image) {
+                    if ($image['type'] != 'primary') {
+                      continue;
+                    }
+                    $reference = $image['id'];
+                    $element['type'] = 'image';
+                    break;
+                  }
+                }
+                if ($element['type'] != 'image') {
+                  break;
+                }
                 if (!empty($storyimages[$reference])) {
                   $figclass = "wp-block-image size-large"; 
                   $thisimg = $storyimages[$reference];
@@ -889,7 +903,9 @@ class NPRAPIWordpress extends NPRAPI {
                   $thiscaption .= $cites;
                   $figcaption = (!empty($fightml) && !empty( $thiscaption)) ? "<figcaption>$thiscaption</figcaption>"  : '';
                   $fightml .= (!empty($fightml) && !empty($figcaption)) ? $figcaption : '';
-                  $body_with_layout .= (!empty($fightml)) ? "<figure class=\"$figclass\">$fightml</figure>\n\n" : ''; 
+                  $body_with_layout .= (!empty($fightml)) ? "<figure class=\"$figclass\">$fightml</figure>\n\n" : '';
+                  // make sure it doesn't get reused;
+                  unset($storyimages[$reference]);
                 }
                 break; 
             }

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -877,7 +877,7 @@ class NPRAPIWordpress extends NPRAPI {
                   $thisimg = $storyimages[$reference];
                   $fightml = !empty( (string)$thisimg['image_url']) ? '<img src="' . (string)$thisimg['image_url'] . '"' : '';
                   $thiscaption = !empty(trim( (string)$thisimg['caption'] )) ? trim( (string)$thisimg['caption'] ) : '';
-                  $fightml .= (!empty($fightml) && !empty( $thiscaption)) ? ' alt="' . $thiscaption . '"' : '';
+                  $fightml .= (!empty($fightml) && !empty( $thiscaption)) ? ' alt="' . strip_tags($thiscaption) . '"' : '';
                   $fightml .= !empty($fightml) ? '>' : '';
                   $figcaption = (!empty($fightml) && !empty( $thiscaption)) ? $thiscaption  : '';
                   $cites = '';

--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -32,6 +32,7 @@ define( 'NPR_BYLINE_META_KEY', 'npr_byline' );
 define( 'NPR_BYLINE_LINK_META_KEY', 'npr_byline_link' );
 define( 'NPR_MULTI_BYLINE_META_KEY', 'npr_multi_byline' );
 define( 'NPR_IMAGE_GALLERY_META_KEY', 'npr_image_gallery');
+define( 'NPR_HTML_ASSETS_META_KEY', 'npr_html_assets');
 define( 'NPR_AUDIO_META_KEY', 'npr_audio');
 define( 'NPR_AUDIO_M3U_META_KEY', 'npr_audio_m3u');
 define( 'NPR_PUB_DATE_META_KEY', 'npr_pub_date');

--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -43,6 +43,8 @@ define( 'NPR_IMAGE_CREDIT_META_KEY', 'npr_image_credit');
 define( 'NPR_IMAGE_AGENCY_META_KEY', 'npr_image_agency');
 define( 'NPR_IMAGE_CAPTION_META_KEY', 'npr_image_caption');
 
+define( 'NPR_OEMBED_META_KEY_PREFIX', 'npr_ds_oembeds_');
+
 define( 'NPR_PUSH_STORY_ERROR', 'npr_push_story_error');
 
 define( 'NPR_MAX_QUERIES', 10 );

--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -44,8 +44,6 @@ define( 'NPR_IMAGE_CREDIT_META_KEY', 'npr_image_credit');
 define( 'NPR_IMAGE_AGENCY_META_KEY', 'npr_image_agency');
 define( 'NPR_IMAGE_CAPTION_META_KEY', 'npr_image_caption');
 
-define( 'NPR_OEMBED_META_KEY_PREFIX', 'npr_ds_oembeds_');
-
 define( 'NPR_PUSH_STORY_ERROR', 'npr_push_story_error');
 
 define( 'NPR_MAX_QUERIES', 10 );

--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -44,6 +44,9 @@ define( 'NPR_IMAGE_CREDIT_META_KEY', 'npr_image_credit');
 define( 'NPR_IMAGE_AGENCY_META_KEY', 'npr_image_agency');
 define( 'NPR_IMAGE_CAPTION_META_KEY', 'npr_image_caption');
 
+define( 'NPR_STORY_HAS_LAYOUT_META_KEY', 'npr_has_layout');
+define( 'NPR_STORY_HAS_VIDEO_META_KEY', 'npr_has_video');
+
 define( 'NPR_PUSH_STORY_ERROR', 'npr_push_story_error');
 
 define( 'NPR_MAX_QUERIES', 10 );

--- a/settings.php
+++ b/settings.php
@@ -166,7 +166,7 @@ function nprstory_query_use_layout_callback() {
   }
   $check_box_string .= "/>";
 
-  echo $check_box_string . "<p>If layout is available will render any YouTube, Tweets, images, or JavaScript-based widgets within the post in the order they appear. CAUTION: This will allow the 'admin' user to post unfiltered content such as JavaScript.</p>";
+  echo $check_box_string . "<p>If layout is available will render any YouTube, Tweets, images, or JavaScript-based widgets within the post in the order they appear. CAUTION: This disables the normal 'wp_kses' filtering for imported posts that prevents any JavaScript from being included in the post.  We assume that NPR Story API posts will not have malicious scripts.</p>";
   wp_nonce_field( 'nprstory_nonce_ds_npr_query_use_layout', 'nprstory_nonce_ds_npr_query_use_layout_name', true, true );
 }
 

--- a/settings.php
+++ b/settings.php
@@ -91,8 +91,14 @@ function nprstory_settings_init() {
     add_settings_field( 'dp_npr_query_run_multi', 'Run the queries on saving changes', 'nprstory_query_run_multi_callback', 'ds_npr_api_get_multi_settings', 'ds_npr_api_get_multi_settings' );
     register_setting( 'ds_npr_api_get_multi_settings', 'dp_npr_query_run_multi' , 'nprstory_validation_callback_checkbox');
 
+
     add_settings_field( 'dp_npr_query_multi_cron_interval', 'Interval to run Get Multi cron', 'nprstory_query_multi_cron_interval_callback', 'ds_npr_api_get_multi_settings', 'ds_npr_api_get_multi_settings' );
     register_setting( 'ds_npr_api_get_multi_settings', 'dp_npr_query_multi_cron_interval', 'intval' );
+
+
+    add_settings_field( 'dp_npr_query_use_layout', 'Use rich layout on pulled posts if available', 'nprstory_query_use_layout_callback', 'ds_npr_api_get_multi_settings', 'ds_npr_api_get_multi_settings' );
+    register_setting( 'ds_npr_api_get_multi_settings', 'dp_npr_query_use_layout' , 'nprstory_validation_callback_checkbox');
+
 
     add_settings_field( 'ds_npr_pull_post_type', 'NPR Pull Post Type', 'nprstory_pull_post_type_callback', 'ds_npr_api', 'ds_npr_api_settings' );
     register_setting( 'ds_npr_api', 'ds_npr_pull_post_type', 'nprstory_validation_callback_select' );
@@ -149,6 +155,19 @@ function nprstory_query_run_multi_callback() {
 
 	echo $check_box_string;
 	wp_nonce_field( 'nprstory_nonce_ds_npr_query_run_multi', 'nprstory_nonce_ds_npr_query_run_multi_name', true, true );
+}
+
+function nprstory_query_use_layout_callback() {
+  $use_layout = get_option('dp_npr_query_use_layout');
+  $check_box_string = "<input id='dp_npr_query_use_layout' name='dp_npr_query_use_layout' type='checkbox' value='true'";
+
+  if ( $use_layout ) {
+    $check_box_string .= ' checked="checked" ';
+  }
+  $check_box_string .= "/>";
+
+  echo $check_box_string . "<p>If layout is available will render any YouTube, Tweets, images, or JavaScript-based widgets within the post in the order they appear. CAUTION: This will allow the 'admin' user to post unfiltered content such as JavaScript.</p>";
+  wp_nonce_field( 'nprstory_nonce_ds_npr_query_use_layout', 'nprstory_nonce_ds_npr_query_use_layout_name', true, true );
 }
 
 function nprstory_query_multi_cron_interval_callback() {

--- a/settings.php
+++ b/settings.php
@@ -166,7 +166,7 @@ function nprstory_query_use_layout_callback() {
   }
   $check_box_string .= "/>";
 
-  echo $check_box_string . "<p>If layout is available will render any YouTube, Tweets, images, or JavaScript-based widgets within the post in the order they appear. CAUTION: This disables the normal 'wp_kses' filtering for imported posts that prevents any JavaScript from being included in the post.  We assume that NPR Story API posts will not have malicious scripts.</p>";
+  echo $check_box_string . "<p>If 'layout' is available in the NPR Story API output for your key, checking this box will import posts with more complex HTML to render any images, YouTube videos, Tweets, iframes, or JavaScript-based widgets within the post in the order they appeared on the NPR website. Only the 'primary' image for the story will be sideloaded into the Media Library, all other images will be linked from NPR.  CAUTION: This disables the normal 'wp_kses' filtering for imported posts that prevents any JavaScript from being included in the post.  We assume that NPR Story API posts will not have malicious scripts.</p>";
   wp_nonce_field( 'nprstory_nonce_ds_npr_query_use_layout', 'nprstory_nonce_ds_npr_query_use_layout_name', true, true );
 }
 


### PR DESCRIPTION
These commits at a settings toggle to optionally check for the existence of a 'layout' section in the NPR API response, and if present uses that layout to pull in order the corresponding paragraphs, images, externalAssets such as YouTube and Twitter oEmbeds, and HtmlAssets that are usually javascript or iframes.  If one of the layout elements is a 'gallery' the primary image for the post is inserted in its place.   

Leaving the toggle unchecked, or if no 'layout' section is found in the API response, leaves the previous handler for creating the post body unaltered.